### PR TITLE
feat: initial seed — github-pr-review-loop skill v0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "qubitrenegade-github-pr-review-loop",
+  "owner": {
+    "name": "qubitrenegade"
+  },
+  "plugins": [
+    {
+      "name": "github-pr-review-loop",
+      "source": "./",
+      "description": "Claude Code skill for running a disciplined GitHub PR review loop with Copilot: triage, empirical dismissal, and when to stop. Scales to multi-PR waves.",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "github-pr-review-loop",
+  "version": "0.1.0",
+  "description": "Claude Code skill for running a disciplined GitHub PR review loop with Copilot: triage, empirical dismissal, and when to stop. Scales to multi-PR waves.",
+  "author": "qubitrenegade",
+  "homepage": "https://github.com/qubitrenegade/github-pr-review-loop",
+  "license": "MIT",
+  "skills": [
+    "skills/github-pr-review-loop"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "github-pr-review-loop",
   "version": "0.1.0",
   "description": "Claude Code skill for running a disciplined GitHub PR review loop with Copilot: triage, empirical dismissal, and when to stop. Scales to multi-PR waves.",
-  "author": "qubitrenegade",
+  "author": { "name": "qubitrenegade" },
   "homepage": "https://github.com/qubitrenegade/github-pr-review-loop",
   "license": "MIT"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,8 +4,5 @@
   "description": "Claude Code skill for running a disciplined GitHub PR review loop with Copilot: triage, empirical dismissal, and when to stop. Scales to multi-PR waves.",
   "author": "qubitrenegade",
   "homepage": "https://github.com/qubitrenegade/github-pr-review-loop",
-  "license": "MIT",
-  "skills": [
-    "skills/github-pr-review-loop"
-  ]
+  "license": "MIT"
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 qubitrenegade
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # github-pr-review-loop
 
 A Claude Code skill for running a disciplined GitHub PR review loop: triage
-every reviewer comment into **apply / dismiss / clarify**, dismiss
-hallucinations with empirical evidence, and stop chasing rounds when Copilot
+every reviewer comment into **apply / dismiss / clarify / defer**, dismiss
+hallucinations with empirical evidence, resolve every thread after replying,
+verify CI is green before merging, and stop chasing rounds when Copilot
 starts repeating itself. Scales from one PR to many with parallel worktrees.
 
 This skill encodes the habits from shipping [clickwork
@@ -22,9 +23,11 @@ PR reviewer turned on.
 
 ## What the skill teaches
 
-- **Triage by category.** Every review finding is one of three things:
-  apply, dismiss, or clarify. Each has a template and a commit-SHA reply
-  convention so the review thread stays navigable.
+- **Triage by category.** Every review finding is one of four things:
+  apply (fix + cite commit SHA), dismiss (reply with empirical evidence),
+  clarify (ask when ambiguous), or defer (valid but out of scope — file a
+  follow-up issue and link it). Each has a template so the review thread
+  stays navigable.
 - **Empirical dismissal.** Copilot hallucinates. Before taking its word,
   `grep -c`, `python -c`, or a test run is cheap. The skill prescribes this
   check on every "this looks broken" claim.
@@ -92,9 +95,9 @@ skills/
 └── github-pr-review-loop/
     ├── SKILL.md                            # Core prompt (loaded when invoked)
     └── references/
-        ├── triage-patterns.md              # apply / dismiss / clarify templates
-        ├── graphql-snippets.md             # requestReviews + comment queries
-        ├── stop-conditions.md              # when to stop chasing
+        ├── triage-patterns.md              # apply / dismiss / clarify / defer templates + resolve discipline
+        ├── graphql-snippets.md             # requestReviews + comment queries + thread resolution + bot-ID discovery
+        ├── stop-conditions.md              # when to stop chasing (incl. "CI must be green" precondition)
         ├── wave-orchestration.md           # multi-PR parallel scaling
         └── case-study-clickwork-1.0.md     # concrete 24-issue run
 ```

--- a/README.md
+++ b/README.md
@@ -85,10 +85,15 @@ If you just want the skill content and don't care about the plugin
 wrapper, copy the skill directory directly into your Claude config:
 
 ```bash
-# Personal (applies to every project)
+# Personal (applies to every project). Ensure the skills dir exists
+# first — a fresh Claude Code install won't have it yet, and cp -r
+# into a missing dir just creates ~/.claude/skills as a copy of the
+# source rather than putting the source inside ~/.claude/skills/.
+mkdir -p ~/.claude/skills
 cp -r skills/github-pr-review-loop ~/.claude/skills/
 
 # Or project-local (applies only to the current repo)
+mkdir -p .claude/skills
 cp -r skills/github-pr-review-loop .claude/skills/
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,27 @@ drives the resulting PRs to merge.
 
 ## Install
 
-### As a plugin
+### As a plugin (recommended)
 
-```bash
-/plugin install https://github.com/qubitrenegade/github-pr-review-loop
+Claude Code's plugin system uses a two-step marketplace flow: add
+this repo as a marketplace, then install the plugin from it.
+
+```
+/plugin marketplace add qubitrenegade/github-pr-review-loop
+/plugin install github-pr-review-loop@qubitrenegade-github-pr-review-loop
 ```
 
-### Manual
+The first command registers the repo as a marketplace (the marketplace
+definition lives at `.claude-plugin/marketplace.json`). The second
+installs the plugin named `github-pr-review-loop` from it.
 
-Copy `skills/github-pr-review-loop/` into your Claude config:
+Or use the interactive UI: `/plugin` → **Discover** tab → search for
+`github-pr-review-loop` → install.
+
+### Manual (skills-only, no plugin infra)
+
+If you just want the skill content and don't care about the plugin
+wrapper, copy the skill directory directly into your Claude config:
 
 ```bash
 # Personal (applies to every project)
@@ -80,9 +92,10 @@ cp -r skills/github-pr-review-loop ~/.claude/skills/
 cp -r skills/github-pr-review-loop .claude/skills/
 ```
 
-Restart your Claude Code session (or start a new one) and the skill's
-metadata is loaded; the full prompt loads when Claude decides the task
-matches.
+This mode installs the skill only; the `.claude-plugin/` manifest
+files aren't needed — skills work standalone. Restart your Claude
+Code session and the skill's metadata is loaded; the full prompt
+loads when Claude decides the task matches.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,27 @@ PR reviewer turned on.
 - **Stop conditions that aren't arbitrary.** One clean Copilot pass (zero
   new findings) is the real signal, not some arbitrary "round 4 threshold".
   The skill lists the signals and an escape hatch.
+- **Small, focused PRs over megas.** Copilot review quality degrades
+  on large diffs — more low-signal findings, more rounds, worse
+  throughput. The skill treats "can this be split?" as a live
+  question during wave planning and "should this be Deferred?" as a
+  live question during the loop.
+- **Plan the waves before opening implementation PRs.** For multi-PR
+  rollouts, roadmap → per-wave plan → implementation PRs, each layer
+  reviewed and merged before the layer below opens. Prevents mid-wave
+  pivots from mismatched API shapes across concurrent branches.
 - **Wave orchestration at scale.** For multi-PR rollouts: parallelism
   policy, worktree-per-PR discipline, scheduled wake-ups instead of
   busy-waiting, overlap prep with Copilot bake time.
+
+## Related skills
+
+Pairs well with `superpowers:brainstorming` (if you have the
+superpowers plugin installed) for the up-front design work the
+wave-planning layer asks for — invoke it before writing the
+roadmap or per-wave plan PR to lock in API shapes and A/B/C
+decisions while they're still cheap to change. This skill then
+drives the resulting PRs to merge.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,114 @@
 # github-pr-review-loop
+
+A Claude Code skill for running a disciplined GitHub PR review loop: triage
+every reviewer comment into **apply / dismiss / clarify**, dismiss
+hallucinations with empirical evidence, and stop chasing rounds when Copilot
+starts repeating itself. Scales from one PR to many with parallel worktrees.
+
+This skill encodes the habits from shipping [clickwork
+1.0.0](https://pypi.org/project/clickwork/) (24 issues, 19 PRs, 1 day of
+parallel waves), generalised so it applies to any repo with GitHub Copilot
+PR reviewer turned on.
+
+## When Claude should invoke this skill
+
+- You've opened a PR and want the agent to drive it through Copilot review
+  to merge, handling each finding correctly instead of thrashing on every
+  suggestion.
+- You're tackling a batch of related issues across many PRs and want to
+  orchestrate parallel loops without cross-wave conflicts.
+- You need to decide whether a Copilot comment is real or a hallucination,
+  and you want evidence-backed dismissal rather than guessing.
+
+## What the skill teaches
+
+- **Triage by category.** Every review finding is one of three things:
+  apply, dismiss, or clarify. Each has a template and a commit-SHA reply
+  convention so the review thread stays navigable.
+- **Empirical dismissal.** Copilot hallucinates. Before taking its word,
+  `grep -c`, `python -c`, or a test run is cheap. The skill prescribes this
+  check on every "this looks broken" claim.
+- **Correct re-request mechanics.** The only way to re-trigger a Copilot
+  review is the `requestReviews(botIds: [...])` GraphQL mutation after you
+  push fixes. `@-mentioning` the reviewer in a comment does nothing. The
+  skill encodes the exact call.
+- **Stop conditions that aren't arbitrary.** One clean Copilot pass (zero
+  new findings) is the real signal, not some arbitrary "round 4 threshold".
+  The skill lists the signals and an escape hatch.
+- **Wave orchestration at scale.** For multi-PR rollouts: parallelism
+  policy, worktree-per-PR discipline, scheduled wake-ups instead of
+  busy-waiting, overlap prep with Copilot bake time.
+
+## Install
+
+### As a plugin
+
+```bash
+/plugin install https://github.com/qubitrenegade/github-pr-review-loop
+```
+
+### Manual
+
+Copy `skills/github-pr-review-loop/` into your Claude config:
+
+```bash
+# Personal (applies to every project)
+cp -r skills/github-pr-review-loop ~/.claude/skills/
+
+# Or project-local (applies only to the current repo)
+cp -r skills/github-pr-review-loop .claude/skills/
+```
+
+Restart your Claude Code session (or start a new one) and the skill's
+metadata is loaded; the full prompt loads when Claude decides the task
+matches.
+
+## Requirements
+
+- `gh` CLI installed and authenticated for the repo you're reviewing in
+- GitHub Copilot PR reviewer enabled on the repo (free for public repos, a
+  subscription item for private)
+- The repo must allow bot review requests (default in GitHub settings;
+  some orgs restrict this)
+
+## Scope
+
+**GitHub-specific.** Copilot PR reviewer is a GitHub feature. The GraphQL
+`requestReviews` mutation is GitHub API. `gh api` is a GitHub CLI. This
+skill is not tested against GitLab Duo or similar; the triage discipline
+would port, but the mechanics would need a rewrite.
+
+**Not included:**
+- Automated implementation of the fixes Copilot suggests (that's your
+  regular development skill set).
+- CI setup. The skill assumes working CI on the repo.
+- Release cutting. This is about getting PRs to merge cleanly, not about
+  tagging + PyPI publishing.
+
+## Structure
+
+```
+skills/
+└── github-pr-review-loop/
+    ├── SKILL.md                            # Core prompt (loaded when invoked)
+    └── references/
+        ├── triage-patterns.md              # apply / dismiss / clarify templates
+        ├── graphql-snippets.md             # requestReviews + comment queries
+        ├── stop-conditions.md              # when to stop chasing
+        ├── wave-orchestration.md           # multi-PR parallel scaling
+        └── case-study-clickwork-1.0.md     # concrete 24-issue run
+```
+
+References load on demand, so the active context stays small even when
+you're deep in a round-5 review loop.
+
+## Contributing
+
+This is v0.1. The discipline captured here is what worked for one
+maintainer on one project. If you use it on a different repo / different
+review tool / different scale and find something that needs refining, open
+an issue or a PR. Real-usage feedback is better than speculation.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ verify CI is green before merging, and stop chasing rounds when Copilot
 starts repeating itself. Scales from one PR to many with parallel worktrees.
 
 This skill encodes the habits from shipping [clickwork
-1.0.0](https://pypi.org/project/clickwork/) (24 issues, 19 PRs, 1 day of
-parallel waves), generalised so it applies to any repo with GitHub Copilot
-PR reviewer turned on.
+1.0.0](https://pypi.org/project/clickwork/) — 24 issues across ~25 PRs in
+~20 hours of parallel waves — generalised so it applies to any repo with
+GitHub Copilot PR reviewer turned on.
 
 ## When Claude should invoke this skill
 

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr-review-loop
-description: Drives a GitHub pull request through its Copilot review loop to merge. Triages each reviewer comment into apply (fix + cite commit SHA), dismiss (reply with empirical evidence), or clarify. Uses the GitHub GraphQL requestReviews mutation to re-trigger Copilot after pushing fixes. Stops when Copilot returns zero new findings or starts repeating itself. Scales to multi-PR batch rollouts via parallel worktrees and scheduled wake-ups. Use when a PR has an open Copilot review that needs to be driven to merge, when a batch of related issues needs to be shipped across many PRs, or when deciding whether a Copilot finding is legitimate or a hallucination.
+description: Drives a GitHub pull request through its Copilot review loop to merge. Triages each reviewer comment into apply (fix + cite commit SHA), dismiss (reply with empirical evidence), clarify (ask when ambiguous), or defer (valid but out of scope — file a follow-up issue). Uses the GitHub GraphQL requestReviews mutation to re-trigger Copilot after pushing fixes, and resolveReviewThread to close each thread loop. Checks every required CI check is green before considering merge. Stops when Copilot returns zero new findings or starts repeating itself. Scales to multi-PR batch rollouts via parallel worktrees and scheduled wake-ups. Use when a PR has an open Copilot review that needs to be driven to merge, when a batch of related issues needs to be shipped across many PRs, or when deciding whether a Copilot finding is legitimate or a hallucination.
 ---
 
 # GitHub PR Review Loop
@@ -22,9 +22,9 @@ mutation, stop when the signal goes quiet.
 If the repo has no Copilot reviewer or the PR has no reviewer assigned,
 this skill doesn't apply — standard PR-review habits are fine.
 
-## The triage — apply, dismiss, or clarify
+## The triage — apply, dismiss, clarify, or defer
 
-Every Copilot inline comment is one of three things. Decide explicitly;
+Every Copilot inline comment is one of four things. Decide explicitly;
 don't guess.
 
 **Apply** — the finding is real. Fix it in a follow-up commit, push,
@@ -98,7 +98,7 @@ That does nothing for bot reviewers. The only mechanism that actually
 re-triggers Copilot is the GraphQL `requestReviews` mutation:
 
 ```bash
-BOT_ID="BOT_kgDOCnlnWA"  # Copilot's global node ID on github.com
+BOT_ID="BOT_kgDOCnlnWA"  # Copilot's global node ID on github.com (see below)
 PR_ID=$(gh pr view <PR_NUM> --repo <OWNER/REPO> --json id --jq .id)
 gh api graphql -f query='
   mutation($prId: ID!, $botId: ID!) {
@@ -108,9 +108,12 @@ gh api graphql -f query='
   }' -f prId="$PR_ID" -f botId="$BOT_ID"
 ```
 
-See [references/graphql-snippets.md](references/graphql-snippets.md) for
-the full GraphQL catalog (list Copilot comments, batch-reply, dismiss
-outstanding).
+`BOT_kgDOCnlnWA` is the observed github.com value. On GitHub
+Enterprise or if the ID has rotated, discover it dynamically from an
+existing Copilot review — see
+[references/graphql-snippets.md](references/graphql-snippets.md)
+for the discovery query and the rest of the catalog (list comments,
+batch-reply, list/resolve threads, check CI status).
 
 Re-request **after** your fix commits have pushed, not before. Copilot
 reviews against the current HEAD of the PR branch; requesting a review
@@ -121,16 +124,49 @@ before your commit lands wastes a pass.
 For a single PR, the loop is this. Repeat until a stop condition fires.
 
 1. Read the latest Copilot review's inline comments.
-2. Triage each comment (apply / dismiss / clarify).
+2. Triage each comment (apply / dismiss / clarify / defer).
 3. Commit all "apply" fixes in one push (batch them — multiple reply
    cycles per push is wasteful).
-4. Post inline replies with commit SHAs / empirical dismissals.
+4. Post inline replies with commit SHAs / empirical dismissals /
+   follow-up issue links. Resolve each thread after replying.
 5. Re-request review via GraphQL mutation.
 6. Wait. Use `ScheduleWakeup` (Claude Code) or a cron / cadence —
    never busy-poll. 4-5 min is a sensible interval.
 7. On wake-up, check status: any new CI failures? any new inline
    comments? any already-addressed comments Copilot re-raised?
 8. Return to step 1 with the new findings, OR fire a stop condition.
+
+## Before merging: CI must be green
+
+**A stop condition firing is not permission to merge — it's permission
+to stop chasing Copilot.** The merge gate is separate: every required
+CI check on the PR head must be in `SUCCESS` or `SKIPPED` state.
+
+```bash
+gh pr view <PR_NUM> --repo <OWNER/REPO> --json statusCheckRollup --jq \
+  '{failed: [.statusCheckRollup[]? | select(.conclusion=="FAILURE") | .name],
+    pending: [.statusCheckRollup[]? | select(.status!="COMPLETED") | .name]}'
+```
+
+If `failed` is non-empty: either fix the code (likely — the CI is
+telling you something real) or fix the workflow (if the failure
+reproduces on `main` unchanged, it's pre-existing infra, not this
+PR's fault — but don't merge past it; file or fix the infra in a
+dedicated PR first).
+
+If `pending` is non-empty: wait. Don't merge mid-CI. Schedule another
+wake-up.
+
+Both empty → CI is green → merge is gated only on Copilot signal
+(stop conditions) and human approval if required.
+
+**Never use `gh pr merge --admin` to bypass a failing required check
+just because "main is also failing so it's not my PR's fault".** If
+main is red for the same reason, main shouldn't merge either —
+that's a broken gate, fix it first. See
+[references/stop-conditions.md](references/stop-conditions.md) under
+"Failure-mode stops" for the clickwork Release-smoke episode that
+taught this lesson the hard way.
 
 ## Stop conditions
 

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -202,6 +202,65 @@ at high volume, thread has devolved, etc.).
   already replied to the original thread. Point at the first reply and
   move on.
 
+## Keep PRs small and focused
+
+Every principle above works better on small PRs. Why:
+
+- Copilot review quality degrades on large diffs — the reviewer has
+  more surface to skim, produces more low-signal findings, and the
+  round count goes up without the signal going up.
+- Smaller PRs mean shorter review loops (fewer findings per round,
+  fewer rounds to converge), so throughput goes up even though PR
+  count does too.
+- A focused PR has a single clear Defer boundary — "this PR is
+  about X; anything else → follow-up issue". Mega-PRs blur the
+  boundary and Copilot's scope-related suggestions become harder
+  to triage.
+- Reverts and bisects are cheap on small PRs, expensive on big ones.
+
+When a wave's plan shows one issue ballooning past ~300 lines of
+diff or touching more than 3-4 files (outside of test files), split
+it into follow-up issues before writing code, not after. See
+[references/wave-orchestration.md](references/wave-orchestration.md)
+for planning patterns and
+[references/triage-patterns.md](references/triage-patterns.md)
+under "Defer" for the right-sized escape hatch once you're mid-PR
+and a finding would balloon the scope.
+
+## Plan the waves before opening PRs
+
+For any multi-PR rollout, the discipline starts before the first
+implementation PR: **write the roadmap as its own PR, merge it,
+write each wave plan as its own PR, merge each**. Every layer gets
+reviewed before code lands under it.
+
+- Roadmap PR pins wave structure, parallelism policy, release
+  target, any cross-cutting decisions.
+- Each wave's plan PR pins per-issue API shapes, branch names,
+  TDD targets, and any wave-internal merge-order constraints.
+- Only after the wave plan merges do the implementation PRs open.
+
+This prevents the expensive mid-wave pivot where three subagents
+have shipped diffs that contradict each other because the API
+shape wasn't locked. It also means the maintainer reviews intent
+at plan time — cheap — rather than discovering it in code review
+of 5 concurrent PRs — expensive.
+
+See [references/wave-orchestration.md](references/wave-orchestration.md)
+for the full hierarchy (roadmap → wave plan → implementation PRs)
+with concrete examples from the clickwork 1.0 cycle.
+
+### Pairs well with superpowers:brainstorming
+
+The "lock API shape upfront" part of wave planning is a
+brainstorming exercise: what are the open questions, what are the
+A/B/C options for each, which does the maintainer pick. The
+`superpowers:brainstorming` skill is built for exactly this kind
+of up-front design conversation — invoke it before writing the
+roadmap or wave plan PR to surface the open decisions and get them
+answered before code starts. This skill's review loop then drives
+the resulting PRs to merge.
+
 ## Scaling to multiple PRs
 
 The same loop runs for each PR in a multi-PR rollout. What changes is

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -280,10 +280,10 @@ for the parallel-waves pattern in detail.
 
 The [clickwork 1.0.0
 case study](references/case-study-clickwork-1.0.md) walks through a real
-24-issue rollout across 4 waves and 19 PRs. Every principle above shows
-up in the narrative with commit SHAs and real Copilot transcripts —
-useful as ground truth when deciding whether this skill's generalisation
-actually applies to your situation.
+24-issue rollout across 4 planning waves + a release cut, ~25 PRs total.
+Every principle above shows up in the narrative with commit SHAs and real
+Copilot transcripts — useful as ground truth when deciding whether this
+skill's generalisation actually applies to your situation.
 
 ## Troubleshooting
 

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -98,8 +98,13 @@ That does nothing for bot reviewers. The only mechanism that actually
 re-triggers Copilot is the GraphQL `requestReviews` mutation:
 
 ```bash
+# Set these first — angle-bracket placeholders are shell I/O
+# redirection tokens and will fail on copy-paste without quoting.
+REPO="<owner>/<repo>"      # e.g. qubitrenegade/github-pr-review-loop
+PR_NUM="<pr-number>"       # e.g. 42
 BOT_ID="BOT_kgDOCnlnWA"  # Copilot's global node ID on github.com (see below)
-PR_ID=$(gh pr view <PR_NUM> --repo <owner>/<repo> --json id --jq .id)
+
+PR_ID=$(gh pr view "$PR_NUM" --repo "$REPO" --json id --jq .id)
 gh api graphql -f query='
   mutation($prId: ID!, $botId: ID!) {
     requestReviews(input: {pullRequestId: $prId, botIds: [$botId]}) {
@@ -148,7 +153,8 @@ TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, or still in-progress —
 blocks merge.
 
 ```bash
-gh pr view <PR_NUM> --repo <owner>/<repo> --json statusCheckRollup --jq \
+# $REPO and $PR_NUM from the earlier snippet
+gh pr view "$PR_NUM" --repo "$REPO" --json statusCheckRollup --jq \
   '{
     blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL") | {name, conclusion}],
     pending: [.statusCheckRollup[]? | select(.status != "COMPLETED") | .name],

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -132,14 +132,20 @@ For a single PR, the loop is this. Repeat until a stop condition fires.
 2. Triage each comment (apply / dismiss / clarify / defer).
 3. Commit all "apply" fixes in one push (batch them — multiple reply
    cycles per push is wasteful).
-4. Post inline replies with commit SHAs / empirical dismissals /
+4. **Sweep before pushing** — grep for any variable, path, or
+   placeholder your fix renamed or restructured, and update every
+   dangling reference. Otherwise the next round catches the
+   dangling reference as its own finding and you cascade into an
+   extra round. See [references/triage-patterns.md](references/triage-patterns.md)
+   under "Sweep before you push" for the pattern.
+5. Post inline replies with commit SHAs / empirical dismissals /
    follow-up issue links. Resolve each thread after replying.
-5. Re-request review via GraphQL mutation.
-6. Wait. Use `ScheduleWakeup` (Claude Code) or a cron / cadence —
+6. Re-request review via GraphQL mutation.
+7. Wait. Use `ScheduleWakeup` (Claude Code) or a cron / cadence —
    never busy-poll. 4-5 min is a sensible interval.
-7. On wake-up, check status: any new CI failures? any new inline
+8. On wake-up, check status: any new CI failures? any new inline
    comments? any already-addressed comments Copilot re-raised?
-8. Return to step 1 with the new findings, OR fire a stop condition.
+9. Return to step 1 with the new findings, OR fire a stop condition.
 
 ## Before merging: CI must be green
 

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: github-pr-review-loop
+description: Drives a GitHub pull request through its Copilot review loop to merge. Triages each reviewer comment into apply (fix + cite commit SHA), dismiss (reply with empirical evidence), or clarify. Uses the GitHub GraphQL requestReviews mutation to re-trigger Copilot after pushing fixes. Stops when Copilot returns zero new findings or starts repeating itself. Scales to multi-PR batch rollouts via parallel worktrees and scheduled wake-ups. Use when a PR has an open Copilot review that needs to be driven to merge, when a batch of related issues needs to be shipped across many PRs, or when deciding whether a Copilot finding is legitimate or a hallucination.
+---
+
+# GitHub PR Review Loop
+
+Drive a PR (or many PRs in parallel) through the Copilot review loop to
+merge. The habit is the same at every scale: push a change, wait for
+Copilot, triage every finding, reply with a commit SHA when you fixed it
+and empirical evidence when you didn't, re-request review via the GraphQL
+mutation, stop when the signal goes quiet.
+
+## When to reach for this skill
+
+- A PR is open on a GitHub repo that has Copilot PR reviewer enabled.
+- Copilot has left (or is about to leave) inline comments you need to
+  process correctly rather than thrash on.
+- You're tackling a batch of related issues and want to run multiple
+  review loops in parallel without them stepping on each other.
+
+If the repo has no Copilot reviewer or the PR has no reviewer assigned,
+this skill doesn't apply — standard PR-review habits are fine.
+
+## The triage — apply, dismiss, or clarify
+
+Every Copilot inline comment is one of three things. Decide explicitly;
+don't guess.
+
+**Apply** — the finding is real. Fix it in a follow-up commit, push,
+then reply to the comment thread citing the commit SHA so the thread is
+navigable when a human skims:
+
+> Fixed in `abc1234` — <one-sentence summary of the fix>.
+
+**Dismiss** — the finding is wrong (hallucination, stale claim, or
+a suggestion that contradicts an intentional design choice). Reply with
+evidence, not just an opinion:
+
+> Dismissing — verified empirically: `grep -c 'foo' src/bar.py` returns
+> 3, so the "foo is never referenced" claim is incorrect.
+
+The evidence format depends on the claim. For "this function doesn't
+exist" use `grep` or `python -c "import x; x.y"`. For "this would
+crash" run the actual import or the unit test. For "the anchor
+doesn't resolve" check the file for the heading. See
+[references/triage-patterns.md](references/triage-patterns.md) for the
+full catalog.
+
+**Clarify** — the finding is ambiguous or you can't tell yet. Ask in
+the thread rather than guessing. Usually a one-liner is enough:
+
+> What specifically would "improve the error path"? The current
+> `ConfigError` already names the key and the offending path; I'm
+> not sure which surface you want changed.
+
+## How to re-trigger review after pushing fixes
+
+**Never @-mention the reviewer in a comment to re-request review.**
+That does nothing for bot reviewers. The only mechanism that actually
+re-triggers Copilot is the GraphQL `requestReviews` mutation:
+
+```bash
+BOT_ID="BOT_kgDOCnlnWA"  # Copilot's global node ID on github.com
+PR_ID=$(gh pr view <PR_NUM> --repo <OWNER/REPO> --json id --jq .id)
+gh api graphql -f query='
+  mutation($prId: ID!, $botId: ID!) {
+    requestReviews(input: {pullRequestId: $prId, botIds: [$botId]}) {
+      pullRequest { number }
+    }
+  }' -f prId="$PR_ID" -f botId="$BOT_ID"
+```
+
+See [references/graphql-snippets.md](references/graphql-snippets.md) for
+the full GraphQL catalog (list Copilot comments, batch-reply, dismiss
+outstanding).
+
+Re-request **after** your fix commits have pushed, not before. Copilot
+reviews against the current HEAD of the PR branch; requesting a review
+before your commit lands wastes a pass.
+
+## The loop
+
+For a single PR, the loop is this. Repeat until a stop condition fires.
+
+1. Read the latest Copilot review's inline comments.
+2. Triage each comment (apply / dismiss / clarify).
+3. Commit all "apply" fixes in one push (batch them — multiple reply
+   cycles per push is wasteful).
+4. Post inline replies with commit SHAs / empirical dismissals.
+5. Re-request review via GraphQL mutation.
+6. Wait. Use `ScheduleWakeup` (Claude Code) or a cron / cadence —
+   never busy-poll. 4-5 min is a sensible interval.
+7. On wake-up, check status: any new CI failures? any new inline
+   comments? any already-addressed comments Copilot re-raised?
+8. Return to step 1 with the new findings, OR fire a stop condition.
+
+## Stop conditions
+
+Stop when any of these fires. Don't keep chasing.
+
+- **Copilot's latest review returned zero new inline comments.** The
+  most reliable signal. One clean pass means the reviewer is done.
+- **Copilot is repeating itself.** The new finding is substantively the
+  same as one you already replied to with a commit SHA or a dismissal.
+  Reply pointing at the original thread ("addressed in `abc1234`, see
+  thread above") and move on; don't change code.
+- **Suggestions are drying up in volume.** Round 1 had 7 findings,
+  round 3 had 2, round 4 has 1 — the signal is consumed. Next pass is
+  usually empty.
+- **The user says "merge it".** Explicit off-ramp, always valid.
+
+See [references/stop-conditions.md](references/stop-conditions.md) for
+the full list including failure-mode stops (reviewer is hallucinating
+at high volume, thread has devolved, etc.).
+
+## What to never do
+
+- **Never @-mention the reviewer in a comment to re-request review.**
+  Use the GraphQL mutation.
+- **Never `--admin`-merge over a failing CI check** unless the check is
+  demonstrably broken and you understand why. If the check is legitimately
+  red, fix the underlying cause (the code, the test, or the workflow) and
+  merge on green. Bypassing CI because it's "inconvenient" is how
+  regressions ship.
+- **Never dismiss a Copilot comment without evidence** just because it
+  feels wrong. A one-line `python -c` or `grep -c` is cheap; use it.
+- **Never change code to silence a repeated Copilot comment** if you've
+  already replied to the original thread. Point at the first reply and
+  move on.
+
+## Scaling to multiple PRs
+
+The same loop runs for each PR in a multi-PR rollout. What changes is
+the orchestration around it.
+
+- One worktree per PR, branched from current main. Isolates concurrent
+  edits so a change in PR #5 doesn't bleed into PR #7.
+- Scheduled wake-ups per PR at staggered intervals so you're not blocked
+  on one PR's Copilot round when the others could be progressing.
+- Overlap the next wave's prep (branch creation, agent briefing) with
+  the current wave's Copilot bake time. Don't idle.
+
+See [references/wave-orchestration.md](references/wave-orchestration.md)
+for the parallel-waves pattern in detail.
+
+## Concrete example
+
+The [clickwork 1.0.0
+case study](references/case-study-clickwork-1.0.md) walks through a real
+24-issue rollout across 4 waves and 19 PRs. Every principle above shows
+up in the narrative with commit SHAs and real Copilot transcripts —
+useful as ground truth when deciding whether this skill's generalisation
+actually applies to your situation.
+
+## Troubleshooting
+
+**Copilot won't review after a `requestReviews` call.** Check the PR's
+"Reviewers" sidebar: if Copilot isn't listed, the repo hasn't been
+enabled for Copilot PR review. Turn it on in repo settings → Pull
+Requests → "Copilot review".
+
+**`BOT_kgDOCnlnWA` gives a "User not found" error.** You used `userIds`
+instead of `botIds` in the mutation. Copilot is a bot, not a user;
+userIds will always 404 for it.
+
+**CI failures repeat across pushes but aren't from my code.** If the
+same workflow fails on `main` too, it's infra (bad cache, flaky
+external service, broken workflow YAML). Fix the workflow in a
+dedicated PR before expecting clean CI on the current one. Don't admin-
+merge past it — that's the anti-pattern in "What to never do".

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -140,31 +140,32 @@ For a single PR, the loop is this. Repeat until a stop condition fires.
 
 **A stop condition firing is not permission to merge — it's permission
 to stop chasing Copilot.** The merge gate is separate: every required
-CI check on the PR head must be in `SUCCESS` or `SKIPPED` state —
-**any other conclusion blocks merge**, including FAILURE, CANCELLED,
-TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, NEUTRAL, and anything
-still in-progress.
+CI check on the PR head must be in a green conclusion. Per GitHub's
+required-check docs, the green set is **SUCCESS, SKIPPED, and
+NEUTRAL** (GitHub treats NEUTRAL as success for dependent checks and
+for required-check gating). Anything else — FAILURE, CANCELLED,
+TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, or still in-progress —
+blocks merge.
 
 ```bash
 gh pr view <PR_NUM> --repo <owner>/<repo> --json statusCheckRollup --jq \
   '{
-    blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion != "SUCCESS" and .conclusion != "SKIPPED")) | {name, conclusion}],
+    blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL") | {name, conclusion}],
     pending: [.statusCheckRollup[]? | select(.status != "COMPLETED") | .name],
-    green: ([.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED"))] | length)
+    green: ([.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))] | length)
   }'
 ```
 
 **Interpret:**
 
-- `blocking == [] && pending == []` → every completed check is SUCCESS
-  or SKIPPED, nothing in-flight → CI gate is clear.
+- `blocking == [] && pending == []` → every completed check is SUCCESS,
+  SKIPPED, or NEUTRAL → CI gate is clear (matches GitHub's own gate).
 - `blocking != []` → investigate by conclusion. FAILURE → the code
   or workflow is broken, fix it. CANCELLED → someone cancelled or a
   concurrency group killed it, re-run. TIMED_OUT → the workflow
   exceeded its limit, either fix the underlying slowness or raise
   the timeout. ACTION_REQUIRED → usually a first-time-contributor
-  approval or secret-access prompt, handle it. Treat all of these
-  as blockers regardless of which non-SUCCESS conclusion fired.
+  approval or secret-access prompt, handle it.
 - `pending != []` → wait. Don't merge mid-CI. Schedule another
   wake-up.
 

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -99,7 +99,7 @@ re-triggers Copilot is the GraphQL `requestReviews` mutation:
 
 ```bash
 BOT_ID="BOT_kgDOCnlnWA"  # Copilot's global node ID on github.com (see below)
-PR_ID=$(gh pr view <PR_NUM> --repo <OWNER/REPO> --json id --jq .id)
+PR_ID=$(gh pr view <PR_NUM> --repo <owner>/<repo> --json id --jq .id)
 gh api graphql -f query='
   mutation($prId: ID!, $botId: ID!) {
     requestReviews(input: {pullRequestId: $prId, botIds: [$botId]}) {
@@ -143,7 +143,7 @@ to stop chasing Copilot.** The merge gate is separate: every required
 CI check on the PR head must be in `SUCCESS` or `SKIPPED` state.
 
 ```bash
-gh pr view <PR_NUM> --repo <OWNER/REPO> --json statusCheckRollup --jq \
+gh pr view <PR_NUM> --repo <owner>/<repo> --json statusCheckRollup --jq \
   '{failed: [.statusCheckRollup[]? | select(.conclusion=="FAILURE") | .name],
     pending: [.statusCheckRollup[]? | select(.status!="COMPLETED") | .name]}'
 ```

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -306,9 +306,11 @@ skill's generalisation actually applies to your situation.
 enabled for Copilot PR review. Turn it on in repo settings → Pull
 Requests → "Copilot review".
 
-**`BOT_kgDOCnlnWA` gives a "User not found" error.** You used `userIds`
-instead of `botIds` in the mutation. Copilot is a bot, not a user;
-userIds will always 404 for it.
+**`BOT_kgDOCnlnWA` gives a "Could not resolve to User node" error.**
+You used `userIds` instead of `botIds` in the mutation. Copilot is a
+bot, not a user. With `gh api graphql`, that shows up as a GraphQL
+error payload (typically HTTP 200 with an `errors` array) naming the
+node type mismatch — not an HTTP 404.
 
 **CI failures repeat across pushes but aren't from my code.** If the
 same workflow fails on `main` too, it's infra (bad cache, flaky

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr-review-loop
-description: Drives a GitHub pull request through its Copilot review loop to merge using a disciplined triage (apply / dismiss / clarify / defer), empirical dismissal of hallucinations, GraphQL-based re-request, thread resolution, and concrete stop conditions. Use when a PR has an open Copilot review that needs to be driven to merge, when running a batch of related PRs in parallel, or when deciding whether a Copilot finding is legitimate or a hallucination.
+description: Drives GitHub PRs through Copilot review to merge via disciplined triage (apply / dismiss / clarify / defer), empirical dismissal of hallucinations, GraphQL-based re-request, and concrete stop conditions. Use for a Copilot-reviewed PR that needs driving to merge, for parallel batches of related PRs, or when deciding whether a Copilot finding is real.
 ---
 
 # GitHub PR Review Loop

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -54,6 +54,43 @@ the thread rather than guessing. Usually a one-liner is enough:
 > `ConfigError` already names the key and the offending path; I'm
 > not sure which surface you want changed.
 
+**Defer** — the finding is correct but fixing it is out of scope for
+the current PR. File a follow-up issue, link it in the reply, move
+on. Example: Copilot flags a subtle race condition in code the PR
+touches but doesn't change; the right fix is a dedicated cycle with
+its own tests, not a drive-by patch in a PR focused on something else.
+
+> Valid concern. Filed as #N for a dedicated cycle; out of scope
+> for this PR which is focused on <X>. The proposed change would
+> <consequence outside this PR's scope>.
+
+`Defer` is a special case of `Apply` where the "apply" happens in a
+separate PR. Same discipline: evidence that the finding is real,
+explicit link to the follow-up so it isn't forgotten.
+
+## After replying, resolve the conversation
+
+Every review-comment thread on a PR has a "Resolve conversation"
+button in the GitHub UI (and a `resolveReviewThread` GraphQL
+mutation — see `references/graphql-snippets.md`). After you reply
+with an apply-SHA, a dismissal, or a clarify question the reviewer
+answers, **mark the thread resolved**. Three reasons:
+
+- The PR's "unresolved conversations" count is a stop-condition
+  signal all by itself. If it's 0, reviewers skimming the PR can
+  trust that every thread was closed loop.
+- A resolved thread collapses by default in the UI, so when you or
+  a human reviewer scroll the PR later, you only see threads that
+  still need attention.
+- It's the same muscle memory as "close an issue" when the work is
+  done. Orphaned open threads rot.
+
+For `Clarify`, resolve only after the reviewer answers and you've
+either Applied or Dismissed the answer. For `Defer`, resolve after
+filing the follow-up issue and linking it — the current PR's thread
+is closed because its disposition is settled, even if the fix lives
+elsewhere.
+
 ## How to re-trigger review after pushing fixes
 
 **Never @-mention the reviewer in a comment to re-request review.**

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr-review-loop
-description: Drives a GitHub pull request through its Copilot review loop to merge. Triages each reviewer comment into apply (fix + cite commit SHA), dismiss (reply with empirical evidence), clarify (ask when ambiguous), or defer (valid but out of scope — file a follow-up issue). Uses the GitHub GraphQL requestReviews mutation to re-trigger Copilot after pushing fixes, and resolveReviewThread to close each thread loop. Checks every required CI check is green before considering merge. Stops when Copilot returns zero new findings or starts repeating itself. Scales to multi-PR batch rollouts via parallel worktrees and scheduled wake-ups. Use when a PR has an open Copilot review that needs to be driven to merge, when a batch of related issues needs to be shipped across many PRs, or when deciding whether a Copilot finding is legitimate or a hallucination.
+description: Drives a GitHub pull request through its Copilot review loop to merge using a disciplined triage (apply / dismiss / clarify / defer), empirical dismissal of hallucinations, GraphQL-based re-request, thread resolution, and concrete stop conditions. Use when a PR has an open Copilot review that needs to be driven to merge, when running a batch of related PRs in parallel, or when deciding whether a Copilot finding is legitimate or a hallucination.
 ---
 
 # GitHub PR Review Loop
@@ -140,25 +140,38 @@ For a single PR, the loop is this. Repeat until a stop condition fires.
 
 **A stop condition firing is not permission to merge — it's permission
 to stop chasing Copilot.** The merge gate is separate: every required
-CI check on the PR head must be in `SUCCESS` or `SKIPPED` state.
+CI check on the PR head must be in `SUCCESS` or `SKIPPED` state —
+**any other conclusion blocks merge**, including FAILURE, CANCELLED,
+TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, NEUTRAL, and anything
+still in-progress.
 
 ```bash
 gh pr view <PR_NUM> --repo <owner>/<repo> --json statusCheckRollup --jq \
-  '{failed: [.statusCheckRollup[]? | select(.conclusion=="FAILURE") | .name],
-    pending: [.statusCheckRollup[]? | select(.status!="COMPLETED") | .name]}'
+  '{
+    blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion != "SUCCESS" and .conclusion != "SKIPPED")) | {name, conclusion}],
+    pending: [.statusCheckRollup[]? | select(.status != "COMPLETED") | .name],
+    green: ([.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED"))] | length)
+  }'
 ```
 
-If `failed` is non-empty: either fix the code (likely — the CI is
-telling you something real) or fix the workflow (if the failure
-reproduces on `main` unchanged, it's pre-existing infra, not this
-PR's fault — but don't merge past it; file or fix the infra in a
-dedicated PR first).
+**Interpret:**
 
-If `pending` is non-empty: wait. Don't merge mid-CI. Schedule another
-wake-up.
+- `blocking == [] && pending == []` → every completed check is SUCCESS
+  or SKIPPED, nothing in-flight → CI gate is clear.
+- `blocking != []` → investigate by conclusion. FAILURE → the code
+  or workflow is broken, fix it. CANCELLED → someone cancelled or a
+  concurrency group killed it, re-run. TIMED_OUT → the workflow
+  exceeded its limit, either fix the underlying slowness or raise
+  the timeout. ACTION_REQUIRED → usually a first-time-contributor
+  approval or secret-access prompt, handle it. Treat all of these
+  as blockers regardless of which non-SUCCESS conclusion fired.
+- `pending != []` → wait. Don't merge mid-CI. Schedule another
+  wake-up.
 
-Both empty → CI is green → merge is gated only on Copilot signal
-(stop conditions) and human approval if required.
+For a failed check: either fix the code (likely — CI is telling you
+something real) or fix the workflow (if the failure reproduces on
+`main` unchanged, it's pre-existing infra, not this PR's fault — but
+don't merge past it; file or fix the infra in a dedicated PR first).
 
 **Never use `gh pr merge --admin` to bypass a failing required check
 just because "main is also failing so it's not my PR's fault".** If

--- a/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
+++ b/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
@@ -21,9 +21,12 @@ skill's generalisation applies to your situation.
 - **Target:** ship 1.0.0 to PyPI same day, update downstream
   consumer (orbit-admin) to 1.0
 - **Final state:** 1.0.0 live on PyPI, signed `v1.0.0` tag, orbit-admin
-  merged to `clickwork>=1.0,<2`, 4 follow-up issues tracked (#61
-  Sigstore, #62 conda-forge, #94 GH Pages, one more)
-- **Total PRs:** 19 in clickwork, 1 in orbit-admin
+  merged to `clickwork>=1.0,<2`, three follow-ups left open on purpose
+  for future cycles (#61 Sigstore attestations + workflow-driven tag
+  signing for 1.0.x, #62 conda-forge recipe for post-1.0, #94 mkdocs
+  docs site)
+- **Total PRs:** ~25 in clickwork (roadmap + wave plans + issue PRs +
+  release cut + post-release polish), 1 in orbit-admin
 - **Copilot rounds total:** ~70 across all PRs
 - **Time:** ~20 hours wall clock, overlapped across waves
 

--- a/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
+++ b/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
@@ -56,7 +56,7 @@ Waves landed as:
 
 Wave 2 had 12 PRs. The parallelism policy was the single biggest
 throughput lever — without it, 12 serial review loops would have taken
-8+ hours; with overlapped bake time, Wave 2 finished in ~3.
+8+ hours; with overlapped bake time, Wave 2 finished in ~3 hours.
 
 ## Wave-by-wave breakdown
 

--- a/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
+++ b/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
@@ -48,8 +48,8 @@ Waves landed as:
 |---|---|---|---|
 | 1 | Package metadata + API policy | #35, #36, #46, #49 | #64, #65 |
 | 2 | Features + infra | #37-#43, #47-#48, #57-#59 | #66-#77 (12 PRs) |
-| 3 | Feature completion | #50-#52, #60b | #78-#81 |
-| 4 | Docs | #53-#56, #58, #54 | #82-#86 |
+| 3 | Feature completion | #50-#52, #60 (part b — `add_global_option` override) | #78-#81 |
+| 4 | Docs | #53-#56, #58 (the #54 config-precedence doc landed here after #80 fail-fast merged) | #82-#86 |
 | 5 | Release cut + polish | version bump | #87 + follow-ups |
 
 Wave 2 had 12 PRs. The parallelism policy was the single biggest

--- a/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
+++ b/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
@@ -1,0 +1,268 @@
+# Case study — clickwork 1.0.0
+
+Concrete run of this skill's pattern on a real repo: shipping
+[clickwork 1.0.0](https://pypi.org/project/clickwork/) (24 issues, 19
+PRs) in ~20 hours. Useful as ground truth when deciding whether this
+skill's generalisation applies to your situation.
+
+## Contents
+
+- Session at a glance
+- Roadmap + wave structure
+- Wave-by-wave breakdown
+- The mistakes that got caught
+- Transcript excerpts — real Copilot findings + replies
+- What did not work
+
+## Session at a glance
+
+- **Repo:** qubitrenegade/clickwork (Python CLI framework)
+- **Starting state:** 0.2.0 on PyPI, 24 issues in scope (#35-#60)
+- **Target:** ship 1.0.0 to PyPI same day, update downstream
+  consumer (orbit-admin) to 1.0
+- **Final state:** 1.0.0 live on PyPI, signed `v1.0.0` tag, orbit-admin
+  merged to `clickwork>=1.0,<2`, 4 follow-up issues tracked (#61
+  Sigstore, #62 conda-forge, #94 GH Pages, one more)
+- **Total PRs:** 19 in clickwork, 1 in orbit-admin
+- **Copilot rounds total:** ~70 across all PRs
+- **Time:** ~20 hours wall clock, overlapped across waves
+
+## Roadmap + wave structure
+
+Session started with a roadmap PR ([#63](https://github.com/qubitrenegade/clickwork/pull/63))
+that pinned:
+
+- 4 waves, each scoped to a coherent theme (packaging, features,
+  polish, docs)
+- Release cut target (single-PR bump of version + CHANGELOG after
+  all waves merge)
+- Parallelism policy **B** (overlap wave N+1 prep during wave N's
+  Copilot bake time)
+
+Waves landed as:
+
+| Wave | Theme | Issues | PRs |
+|---|---|---|---|
+| 1 | Package metadata + API policy | #35, #36, #46, #49 | #64, #65 |
+| 2 | Features + infra | #37-#43, #47-#48, #57-#59 | #66-#77 (12 PRs) |
+| 3 | Feature completion | #50-#52, #60b | #78-#81 |
+| 4 | Docs | #53-#56, #58, #54 | #82-#86 |
+| 5 | Release cut + polish | version bump | #87 + follow-ups |
+
+Wave 2 had 12 PRs. The parallelism policy was the single biggest
+throughput lever — without it, 12 serial review loops would have taken
+8+ hours; with overlapped bake time, Wave 2 finished in ~3.
+
+## Wave-by-wave breakdown
+
+### Wave 1 (packaging)
+
+- PRs: #64 (package metadata), #65 (API policy)
+- Sequential (#64 must land before #65 can reference the published
+  API surface)
+- Low findings count per PR — mostly trove classifier nits, link
+  checks, wording
+
+### Wave 2 (features + infra, 12 PRs)
+
+- Dispatched as full parallel (policy B with wave 1 merged first)
+- One worktree per PR under `clickwork.worktrees/<name>-<issue>`
+- Scheduled wake-ups at 4-5 min intervals, staggered by 30s across
+  PRs so all 12 reviews didn't fire simultaneously
+- Several PRs needed 4-6 Copilot rounds. One needed 7 when a
+  conftest monkeypatch signature drift surfaced late.
+- Wave merged in ~3 hours with no cross-PR conflicts.
+
+### Wave 3 (feature completion)
+
+- 4 PRs, mostly overlapping with wave 2's late review rounds
+- Wave 3's #80 introduced a fail-fast behavior (`ConfigError` on
+  undefined `env`). Two other PRs in wave 3 (#79 mixed-discovery
+  tests, #81 `add_global_option` semantics) had merge-order
+  dependencies on #80's error shape.
+- Resolved by explicit merge-ordering in the wave plan.
+
+### Wave 4 (docs)
+
+- 5 docs PRs (MIGRATING, PLUGINS, SECURITY, CONTRIBUTING, GUIDE
+  config precedence)
+- Much higher review volume per PR because docs expose hallucinations
+  (Copilot sometimes says "this link is broken" when it isn't — the
+  evidence-based dismissal pattern closes these fast)
+- Case study fixture for `triage-patterns.md` examples
+
+### Release cut
+
+- Version bump PR (#87): pyproject 0.2.0 → 1.0.0, CHANGELOG 1.0.0
+  entry, trove classifier Beta → Production/Stable
+- Signed tag pushed by the human maintainer with `git tag -s v1.0.0`
+  after `export GPG_TTY=$(tty)` (captured in the release runbook PR
+  #93)
+- Tag-push triggered `publish.yml` which was itself rewritten mid-
+  session in PR #90 to do build + create-release + PyPI publish in
+  one flow (the original `on: release.published` trigger required a
+  manual `gh release create` step, which broke the "push the tag =
+  release" expectation)
+
+## The mistakes that got caught
+
+Three real mistakes happened during this session. All got caught by
+the loop discipline — worth studying because they show failure modes
+the skill explicitly warns against.
+
+### 1. Admin-merging over failing CI
+
+**What happened.** Several wave 2 PRs showed the Release smoke job
+failing, and the main branch ALSO showed it failing. The agent
+rationalised "same failure on main = pre-existing infra, not a
+blocker" and used `gh pr merge --admin` to merge the PRs.
+
+**What was wrong.** The Release smoke job was failing for a real
+reason (the workflow used `uv venv` which doesn't install pip, but
+then called `/tmp/wheel-smoke/bin/pip install`). The workflow was
+broken. Merging past it didn't fix anything; it just added more PRs
+whose release-smoke signal was untrusted.
+
+**What fixed it.** Maintainer caught it. PR #88 rewrote the smoke
+workflow to use `uv pip install --python` instead of the pip-less
+venv's pip. After #88 merged, Release smoke went green across all
+subsequent PRs and the signal was trustworthy again.
+
+**Lesson.** Don't admin-merge over failing CI, even if the same
+failure appears on main. "Infra is broken" is a reason to fix the
+infra, not a reason to ignore the gate. Captured in the skill's
+"What to never do" list.
+
+### 2. Wrong branch parent
+
+**What happened.** After merging a few PRs, the agent opened PR #90
+from a branch that had been created from `release/1.0.0` (which
+squash-merged into main) instead of `main`. The PR diff showed 6
+files changed when only 1 was intended, because git couldn't tell
+the already-squashed commits were redundant with the current main.
+
+**What fixed it.** `git rebase --onto origin/main release/1.0.0
+<branch>` cleaned up the diff to just the intended file.
+
+**Lesson.** When merging squash-style, cleanly delete the merged
+branches locally before starting new work. Branch off `origin/main`
+explicitly every time: `git checkout -b <new> origin/main`. The skill's
+wave-orchestration reference covers this as worktree-per-PR discipline.
+
+### 3. Wrong release trigger
+
+**What happened.** `publish.yml` triggered on `release.published`,
+which meant pushing the `v1.0.0` tag didn't actually ship anything
+— the agent had to follow up with `gh release create` to fire the
+workflow.
+
+**What was wrong.** The maintainer had expected "push the tag =
+release" from the start (matches the pattern in the sibling
+orbit-widener repo's `release.yml`). The trigger mismatch was not
+the agent's mistake (the workflow predated the session), but the
+agent hadn't noticed + flagged it before the 0.2.0 cut, and only
+surfaced it mid-1.0 work when the maintainer asked why the tag
+push did nothing.
+
+**What fixed it.** PR #90 rewrote `publish.yml` to `on: push: tags:
+['v*']` with a 3-stage flow matching orbit-widener's pattern: build
+→ create release (via `softprops/action-gh-release@v2`) → PyPI
+publish.
+
+**Lesson.** Check the release trigger early. "It worked last time"
+is not a guarantee it worked the way the maintainer expected.
+
+## Transcript excerpts — real Copilot findings
+
+Sample Copilot findings and the replies that closed them, pulled from
+the clickwork 1.0 PRs. Shows the triage patterns in context.
+
+### Apply (Copilot right, fix + SHA)
+
+> **Copilot on PR #87, line 3:** `version` is bumped to 1.0.0 here,
+> but the runtime version constant is still `__version__ = "0.2.0"`
+> in `src/clickwork/__init__.py`, which will make
+> `clickwork.__version__` (and any `--version` functionality that
+> relies on it) report the stale value.
+
+Reply:
+
+> Fixed in `bb56bfc` — bumped `__version__` to 1.0.0 in
+> src/clickwork/__init__.py. Good catch, this would have broken any
+> consumer's `--version` resolution.
+
+Later refined to `importlib.metadata.version("clickwork")` in
+commit `3ca869a` so the two can't drift again.
+
+### Dismiss (Copilot wrong, evidence dismissal)
+
+> **Copilot on PR #83, line 238:** The cross-reference link to
+> `LLM_REFERENCE.md#common-footguns` appears to be broken:
+> `docs/LLM_REFERENCE.md` currently has no matching section/anchor.
+
+Reply after verifying:
+
+> Dismissing (hallucination): `docs/LLM_REFERENCE.md` line 184 has
+> `## Common Footguns` which renders as anchor `#common-footguns`
+> under GitHub-flavored Markdown. The link resolves.
+
+Evidence command used: `grep -nE '^## Common' docs/LLM_REFERENCE.md`
+— returned the heading, confirmed the anchor.
+
+### Apply (subtle accuracy issue)
+
+> **Copilot on PR #89, line 133:** The new re-invocation paragraph
+> says `setup_logging()` finds any existing `_clickwork_owned`
+> handler and reuses it in place. That's not always true: when
+> `_host_root_is_configured()` is true, the implementation
+> explicitly REMOVES the clickwork-owned handler.
+
+Reply:
+
+> Fixed in `9bf4cfd` — split the re-invocation paragraph into two
+> explicit bullets: standalone CLI mode reuses the `_clickwork_owned`
+> stream handler in place; host-configured mode actively
+> `removeHandler()`-s it so records only flow through the host's
+> root. Also added
+> `test_reinvocation_evicts_stream_handler_when_host_configures_after`
+> pinning the specific transition path you flagged.
+
+This was the kind of catch that's hard without a reviewer who reads
+the code carefully — substantively correct, subtle, and would have
+shipped a doc that was accurate-in-one-mode, wrong-in-the-other.
+
+### Copilot repeats itself
+
+On PR #82, Copilot raised "docs/LLM_REFERENCE.md#common-footguns is
+broken" in round 2, got dismissed with the same `grep` evidence as
+PR #83, then raised the same finding again in round 3.
+
+Round-3 reply:
+
+> Same as addressed in round 2 (see thread above). `grep -nE
+> '^## Common' docs/LLM_REFERENCE.md` returns line 184; anchor is
+> valid. Not changing the link.
+
+No code change. PR merged.
+
+## What did not work
+
+Not everything in the session's first attempt stuck.
+
+- **Initial stop condition of "2 clean rounds"** — replaced with "1
+  clean round" after observing that the second round almost always
+  returned empty and the wait was pure cost. Now the recommendation
+  in this skill.
+- **Planning Sigstore for 1.0.0** — descoped to 1.0.1 (tracked in
+  #61) when it became clear the workflow-driven signing setup was
+  its own multi-PR mini-cycle.
+- **Attempting to `--admin` past Release smoke failures.** Got
+  caught, led to PR #88 (fix the actual workflow).
+- **Forgot `GPG_TTY=$(tty)` on the first `git tag -s` attempt.**
+  The first tag sign failed with `Inappropriate ioctl for device`
+  because pinentry couldn't find a TTY. Now documented in
+  CONTRIBUTING.md and in the skill's troubleshooting section.
+
+The session landed 1.0.0 anyway because the loop discipline caught
+most of these before they caused lasting damage, and the maintainer
+caught the rest in time.

--- a/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
+++ b/skills/github-pr-review-loop/references/case-study-clickwork-1.0.md
@@ -1,9 +1,11 @@
 # Case study — clickwork 1.0.0
 
 Concrete run of this skill's pattern on a real repo: shipping
-[clickwork 1.0.0](https://pypi.org/project/clickwork/) (24 issues, 19
-PRs) in ~20 hours. Useful as ground truth when deciding whether this
-skill's generalisation applies to your situation.
+[clickwork 1.0.0](https://pypi.org/project/clickwork/) — 24 issues
+closed across ~25 PRs (roadmap + per-wave plans + 23 implementation
+PRs + release cut + polish follow-ups) in ~20 hours. Useful as ground
+truth when deciding whether this skill's generalisation applies to
+your situation.
 
 ## Contents
 
@@ -47,7 +49,7 @@ Waves landed as:
 | Wave | Theme | Issues | PRs |
 |---|---|---|---|
 | 1 | Package metadata + API policy | #35, #36, #46, #49 | #64, #65 |
-| 2 | Features + infra | #37-#43, #47-#48, #57-#59 | #66-#77 (12 PRs) |
+| 2 | Features + infra | #37-#43, #47-#48, #57, #59 | #66-#77 (12 PRs) |
 | 3 | Feature completion | #50-#52, #60 (part b — `add_global_option` override) | #78-#81 |
 | 4 | Docs | #53-#56, #58 (the #54 config-precedence doc landed here after #80 fail-fast merged) | #82-#86 |
 | 5 | Release cut + polish | version bump | #87 + follow-ups |

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -9,6 +9,9 @@ API. All shell-safe; all assume `gh` is authenticated.
 - Re-request Copilot review after a push
 - List a PR's inline comments (all, or latest round only)
 - Reply to a specific inline comment
+- List review threads with their resolved state + thread IDs
+- Resolve a review thread after replying
+- Bulk-resolve all threads you've already replied to
 - Check which reviews exist and when
 - Check CI status on the current PR head
 - Get PR's GraphQL node ID
@@ -95,6 +98,114 @@ reply 3106073129 "Fixed in acc31d3 — stub now forwards non-clickwork queries t
 reply 3106083785 "Fixed in 0e9fc99 — switched to git+https."
 reply 3106088847 "Dismissing — see evidence: \`grep -c common-footguns docs/LLM_REFERENCE.md\` returns 1."
 ```
+
+## List review threads with resolved state
+
+Threads are the grouping above individual inline comments — each
+thread has an `isResolved` flag that drives the PR's "unresolved
+conversations" counter. To work with thread resolution you need the
+thread ID (not the comment ID).
+
+```bash
+OWNER=<owner>
+REPO=<repo>
+PR_NUM=<pr-number>
+
+gh api graphql -f query='
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 5) {
+              nodes {
+                id
+                author { login }
+                body
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUM" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | {id, isResolved, first_author: .comments.nodes[0].author.login, first_body: .comments.nodes[0].body[0:100]}'
+```
+
+Shows each thread's ID, whether it's resolved, and the opener's
+login + first 100 chars of their comment (enough to map thread IDs
+to the findings you're tracking).
+
+## Resolve a review thread after replying
+
+After you've posted your reply (apply SHA / dismiss evidence / defer
++ issue link), mark the thread resolved:
+
+```bash
+THREAD_ID=<from reviewThreads query above>
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="$THREAD_ID"
+```
+
+Expected response:
+
+```json
+{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}
+```
+
+To unresolve (rare — usually when reopening a debate):
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    unresolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="$THREAD_ID"
+```
+
+## Bulk-resolve all threads you've already replied to
+
+Common case after a round of fixes: you've replied to 6 threads
+with apply SHAs, now you want to resolve them all in one shot.
+
+```bash
+OWNER=<owner>; REPO=<repo>; PR_NUM=<N>; ME=<your-github-login>
+
+# 1. Get all unresolved threads
+UNRESOLVED=$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100) {
+          nodes { id isResolved comments(first: 20) { nodes { author { login } } } }
+        }
+      }
+    }
+  }' -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUM" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select([.comments.nodes[].author.login] | any(. == "'"$ME"'")) | .id')
+
+# 2. Resolve each
+for tid in $UNRESOLVED; do
+  gh api graphql -f query='
+    mutation($threadId: ID!) {
+      resolveReviewThread(input: {threadId: $threadId}) {
+        thread { isResolved }
+      }
+    }' -f threadId="$tid" >/dev/null
+  echo "Resolved $tid"
+done
+```
+
+The filter `any(author == $ME)` limits resolution to threads YOU
+replied on. Don't bulk-resolve threads you haven't actually engaged
+with; that's drive-by closing without evidence.
 
 ## Check which reviews exist
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -74,13 +74,20 @@ gh api graphql -f query='
       }
     }
   }' -F owner=<owner> -F name=<repo> -F number=<pr-with-copilot-review> \
-  --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | {id, login}'
+  --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | select(.author.login == "copilot-pull-request-reviewer") | {id, login}'
 ```
 
 `last: 20` pulls the 20 most recent reviews rather than the oldest
 20. On a PR that's been through many review cycles (especially
 multi-round loops), Copilot's reviews are near the end of the
 timeline; using `first:` without an `orderBy` can skip them.
+
+The extra `login == "copilot-pull-request-reviewer"` filter is so
+the query stays unambiguous on repos that use other bot reviewers
+(CI bots, third-party review services) which would otherwise also
+match `__typename == "Bot"`. If GitHub ever renames Copilot's bot
+account, drop the login filter, see all matching Bot reviews, and
+identify the right one manually.
 
 Any PR that has already been reviewed by Copilot will work. Save the
 resulting `id` as your `BOT_ID` for the `requestReviews` mutation.
@@ -277,7 +284,7 @@ UNRESOLVED=$(gh api graphql -f query='
     repository(owner: $owner, name: $name) {
       pullRequest(number: $number) {
         reviewThreads(first: 100) {
-          nodes { id isResolved comments(first: 20) { nodes { author { login } } } }
+          nodes { id isResolved comments(last: 20) { nodes { author { login } } } }
         }
       }
     }
@@ -299,6 +306,13 @@ done
 The filter `any(author == $ME)` limits resolution to threads YOU
 replied on. Don't bulk-resolve threads you haven't actually engaged
 with; that's drive-by closing without evidence.
+
+`comments(last: 20)` pulls the most recent 20 comments from each
+thread (not the earliest 20). Your reply is the most recent comment
+you made on the thread, so `last:` makes the "have I replied?" check
+reliable even on threads with more than 20 comments. For the edge
+case of a thread with 20+ comments where YOUR reply is older than
+the 20 most-recent, raise the limit or paginate.
 
 ## Check which reviews exist
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -1,7 +1,25 @@
 # GraphQL + gh CLI snippets
 
 Exact commands for interacting with Copilot reviews through the GitHub
-API. All shell-safe; all assume `gh` is authenticated.
+API.  All snippets assume `gh` is authenticated and that the shell
+variables below are set; populate them before running anything in
+this file so the commands are copy-paste-safe:
+
+```bash
+OWNER="<owner>"          # e.g. qubitrenegade
+NAME="<repo>"            # bare repo name, e.g. github-pr-review-loop
+REPO="$OWNER/$NAME"      # combined slug for REST endpoints
+PR_NUM="<pr-number>"     # e.g. 42
+```
+
+Why a preamble + why the quotes around the RHS: angle-bracket
+placeholders like `<owner>` are I/O redirection tokens in bash/zsh,
+even inside an assignment (`OWNER=<owner>` tries to read from a
+file named `owner` and fails with "No such file or directory").
+Quoting `<owner>` on the RHS makes the placeholder a string literal
+so the line is copy-paste-safe, then the user substitutes the real
+value.  Downstream commands reference `"$OWNER"` / `"$REPO"` /
+etc, which is both safe and idiomatic.
 
 ## Contents
 
@@ -82,7 +100,7 @@ gh api graphql -f query='
         }
       }
     }
-  }' -F owner=<owner> -F name=<name> -F number=<pr-with-recent-copilot-review> \
+  }' -F owner="$OWNER" -F name="$NAME" -F number="$PR_NUM" \
   --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | select(.author.login == "copilot-pull-request-reviewer") | .author | {id, login}'
 ```
 
@@ -111,8 +129,7 @@ Push your fix commits first, then:
 
 ```bash
 BOT_ID="BOT_kgDOCnlnWA"
-PR_NUM=<pr-number>
-REPO=<owner>/<repo>
+# PR_NUM and REPO come from the shell-setup preamble at the top of this file.
 
 PR_ID=$(gh pr view "$PR_NUM" --repo "$REPO" --json id --jq .id)
 
@@ -183,7 +200,7 @@ round" reading.
 ## Reply to a specific inline comment
 
 ```bash
-COMMENT_ID=<id-from-list-above>
+COMMENT_ID="<id-from-list-above>"
 gh api "repos/$REPO/pulls/$PR_NUM/comments/$COMMENT_ID/replies" \
   -f body="Fixed in abc1234 — concise description of the fix."
 ```
@@ -228,9 +245,7 @@ reviewThreads(first: 1) { totalCount }
 ```
 
 ```bash
-OWNER=<owner>
-NAME=<repo>
-PR_NUM=<pr-number>
+# OWNER, NAME, PR_NUM from the shell-setup preamble.
 
 gh api graphql -f query='
   query($owner: String!, $name: String!, $number: Int!) {
@@ -265,7 +280,7 @@ After you've posted your reply (apply SHA / dismiss evidence / defer
 + issue link), mark the thread resolved:
 
 ```bash
-THREAD_ID=<from reviewThreads query above>
+THREAD_ID="<from reviewThreads query above>"
 gh api graphql -f query='
   mutation($threadId: ID!) {
     resolveReviewThread(input: {threadId: $threadId}) {
@@ -297,7 +312,8 @@ Common case after a round of fixes: you've replied to 6 threads
 with apply SHAs, now you want to resolve them all in one shot.
 
 ```bash
-OWNER=<owner>; NAME=<repo>; PR_NUM=<N>; ME=<your-github-login>
+# OWNER, NAME, PR_NUM from the shell-setup preamble.  ME is new:
+ME="<your-github-login>"   # e.g. qubitrenegade
 
 # 1. Get all unresolved threads
 UNRESOLVED=$(gh api graphql -f query='

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -62,7 +62,7 @@ gh api graphql -f query='
   query($owner: String!, $name: String!, $number: Int!) {
     repository(owner: $owner, name: $name) {
       pullRequest(number: $number) {
-        reviews(last: 20) {
+        reviews(last: 50) {
           nodes {
             author {
               __typename
@@ -73,14 +73,18 @@ gh api graphql -f query='
         }
       }
     }
-  }' -F owner=<owner> -F name=<repo> -F number=<pr-with-copilot-review> \
+  }' -F owner=<owner> -F name=<name> -F number=<pr-with-recent-copilot-review> \
   --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | select(.author.login == "copilot-pull-request-reviewer") | {id, login}'
 ```
 
-`last: 20` pulls the 20 most recent reviews rather than the oldest
-20. On a PR that's been through many review cycles (especially
+`last: 50` pulls the 50 most recent reviews rather than the oldest
+50. On a PR that's been through many review cycles (especially
 multi-round loops), Copilot's reviews are near the end of the
-timeline; using `first:` without an `orderBy` can skip them.
+timeline; using `first:` without an `orderBy` can skip them. 50
+covers the typical review-loop depth (clickwork 1.0 topped out
+around 8 per PR); if you're on a PR that has genuinely had more
+than 50 reviews, pass `after:` cursor pagination or pick a less
+saturated PR from the same repo.
 
 The extra `login == "copilot-pull-request-reviewer"` filter is so
 the query stays unambiguous on repos that use other bot reviewers

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -5,7 +5,7 @@ API. All shell-safe; all assume `gh` is authenticated.
 
 ## Contents
 
-- Copilot's bot ID (stable across repos)
+- Copilot's bot ID (observed github.com value + runtime discovery)
 - Re-request Copilot review after a push
 - List a PR's inline comments (all, or latest round only)
 - Reply to a specific inline comment
@@ -109,10 +109,14 @@ Copilot will typically start a new review within 30-90 seconds.
 
 ## List inline comments on a PR
 
+Use `--paginate` so large PRs don't silently truncate at 100
+comments. A single page is 100 items; `--paginate` walks every page
+and concatenates the JSON arrays.
+
 **All inline comments (including replies):**
 
 ```bash
-gh api "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
+gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
   '.[] | {id, user: .user.login, in_reply_to_id, line, path, body: (.body[0:120])}'
 ```
 
@@ -121,15 +125,24 @@ gh api "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
 ```bash
 # Find when the latest Copilot review was submitted
 LAST_COPILOT=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviews --jq \
-  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt')
+  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt // empty')
+
+if [ -z "$LAST_COPILOT" ]; then
+  echo "No Copilot review yet on this PR." >&2
+  exit 1
+fi
 
 # Pull only top-level comments (not replies) newer than that timestamp
-gh api "repos/$REPO/pulls/$PR_NUM/comments?sort=created&direction=desc&per_page=100" --jq \
+gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?sort=created&direction=desc&per_page=100" --jq \
   "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at > \"$LAST_COPILOT\")] | .[] | {id, line, path, body: (.body[0:200])}"
 ```
 
 `in_reply_to_id == null` filters out Copilot's replies to your replies
 (which do happen occasionally).
+
+Without `--paginate`, a PR with >100 comments will silently drop
+everything after the first page and you can get a false "clean
+round" reading.
 
 ## Reply to a specific inline comment
 
@@ -163,6 +176,20 @@ endpoints (`repos/$REPO/...`), and `OWNER=<owner>` + `NAME=<repo>`
 as two separate fields for GraphQL `repository(owner:, name:)`
 queries. Don't reuse `REPO` as the bare-name GraphQL variable —
 copy/paste across sections will break.
+
+**Pagination note.** `reviewThreads(first: 100)` returns the first
+100 threads. Most PRs have fewer; the clickwork 1.0 PRs maxed out
+around 15 threads each. For a PR with more than 100 threads, this
+query silently undercounts — both the listing and any
+"unresolved === 0" check downstream become wrong. If your PR has
+over ~80 threads, loop with the GraphQL `pageInfo.endCursor` +
+`after:` cursor; for everyday PRs the simple form below is fine.
+Add a `totalCount` read on `reviewThreads` if you want an early
+check:
+
+```graphql
+reviewThreads(first: 1) { totalCount }
+```
 
 ```bash
 OWNER=<owner>

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -19,14 +19,50 @@ API. All shell-safe; all assume `gh` is authenticated.
 
 ## Copilot's bot ID
 
-GitHub's Copilot PR reviewer has a stable global node ID:
+On github.com, Copilot's PR reviewer is a `Bot` account (REST
+`user.type = "Bot"`, `user.login = "Copilot"`) with this global node
+ID:
 
 ```
 BOT_kgDOCnlnWA
 ```
 
+Observed stable across the clickwork 1.0 cycle (Apr 2026). GraphQL
+node IDs are opaque implementation details in principle — the skill
+treats this value as the github.com default and provides a discovery
+helper below for anyone on GitHub Enterprise, a different instance,
+or a future github.com where the ID has rotated.
+
 Use it in the `botIds` field of `requestReviews`. Do NOT pass it as
 `userIds` — Copilot is a bot, not a user, and userIds will 404.
+
+### Discovering the bot ID at runtime
+
+If `BOT_kgDOCnlnWA` doesn't work (wrong instance, rotated ID, etc.),
+look it up from an existing Copilot review on any PR in the repo:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        reviews(first: 10) {
+          nodes {
+            author {
+              __typename
+              ... on Bot { id login }
+              ... on User { id login }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner=<owner> -F name=<repo> -F number=<pr-with-copilot-review> \
+  --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | {id, login}'
+```
+
+Any PR that has already been reviewed by Copilot will work. Save the
+resulting `id` as your `BOT_ID` for the `requestReviews` mutation.
 
 ## Re-request review after a push
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -343,7 +343,7 @@ the 20 most-recent, raise the limit or paginate.
 
 ```bash
 gh pr view "$PR_NUM" --repo "$REPO" --json reviews --jq \
-  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | {count: length, last: last | .submittedAt}'
+  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | {count: length, last: (last | .submittedAt)}'
 ```
 
 Useful for confirming whether a re-request actually fired a new pass.

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -1,0 +1,180 @@
+# GraphQL + gh CLI snippets
+
+Exact commands for interacting with Copilot reviews through the GitHub
+API. All shell-safe; all assume `gh` is authenticated.
+
+## Contents
+
+- Copilot's bot ID (stable across repos)
+- Re-request Copilot review after a push
+- List a PR's inline comments (all, or latest round only)
+- Reply to a specific inline comment
+- Check which reviews exist and when
+- Check CI status on the current PR head
+- Get PR's GraphQL node ID
+- Failure modes
+
+## Copilot's bot ID
+
+GitHub's Copilot PR reviewer has a stable global node ID:
+
+```
+BOT_kgDOCnlnWA
+```
+
+Use it in the `botIds` field of `requestReviews`. Do NOT pass it as
+`userIds` — Copilot is a bot, not a user, and userIds will 404.
+
+## Re-request review after a push
+
+Push your fix commits first, then:
+
+```bash
+BOT_ID="BOT_kgDOCnlnWA"
+PR_NUM=<pr-number>
+REPO=<owner>/<repo>
+
+PR_ID=$(gh pr view "$PR_NUM" --repo "$REPO" --json id --jq .id)
+
+gh api graphql -f query='
+  mutation($prId: ID!, $botId: ID!) {
+    requestReviews(input: {pullRequestId: $prId, botIds: [$botId]}) {
+      pullRequest { number }
+    }
+  }' -f prId="$PR_ID" -f botId="$BOT_ID"
+```
+
+Expected response:
+
+```json
+{"data":{"requestReviews":{"pullRequest":{"number":<N>}}}}
+```
+
+Copilot will typically start a new review within 30-90 seconds.
+
+## List inline comments on a PR
+
+**All inline comments (including replies):**
+
+```bash
+gh api "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
+  '.[] | {id, user: .user.login, in_reply_to_id, line, path, body: (.body[0:120])}'
+```
+
+**Only Copilot's top-level comments from the latest round:**
+
+```bash
+# Find when the latest Copilot review was submitted
+LAST_COPILOT=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviews --jq \
+  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt')
+
+# Pull only top-level comments (not replies) newer than that timestamp
+gh api "repos/$REPO/pulls/$PR_NUM/comments?sort=created&direction=desc&per_page=100" --jq \
+  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at > \"$LAST_COPILOT\")] | .[] | {id, line, path, body: (.body[0:200])}"
+```
+
+`in_reply_to_id == null` filters out Copilot's replies to your replies
+(which do happen occasionally).
+
+## Reply to a specific inline comment
+
+```bash
+COMMENT_ID=<id-from-list-above>
+gh api "repos/$REPO/pulls/$PR_NUM/comments/$COMMENT_ID/replies" \
+  -f body="Fixed in abc1234 — concise description of the fix."
+```
+
+For batch replies across many findings, drive this in a shell loop:
+
+```bash
+reply() {
+  gh api "repos/$REPO/pulls/$PR_NUM/comments/$1/replies" -f body="$2"
+}
+
+reply 3106073129 "Fixed in acc31d3 — stub now forwards non-clickwork queries through the real impl."
+reply 3106083785 "Fixed in 0e9fc99 — switched to git+https."
+reply 3106088847 "Dismissing — see evidence: \`grep -c common-footguns docs/LLM_REFERENCE.md\` returns 1."
+```
+
+## Check which reviews exist
+
+```bash
+gh pr view "$PR_NUM" --repo "$REPO" --json reviews --jq \
+  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | {count: length, last: last | .submittedAt}'
+```
+
+Useful for confirming whether a re-request actually fired a new pass.
+If `last` hasn't advanced past the expected timestamp, Copilot hasn't
+queued a review yet (sometimes takes a minute or two, sometimes the
+re-request was dropped because there were no new commits to review
+against).
+
+## Check CI status on the current PR head
+
+```bash
+gh pr view "$PR_NUM" --repo "$REPO" --json statusCheckRollup --jq \
+  '{
+     failed: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name],
+     pending: [.statusCheckRollup[] | select(.status!="COMPLETED") | .name],
+     passing: ([.statusCheckRollup[] | select(.conclusion=="SUCCESS")] | length)
+   }'
+```
+
+Interpret:
+
+- Empty `failed`, empty `pending` → ready to consider merging.
+- Non-empty `failed` → investigate. If the same check also fails on
+  `main`, it's infra (see `stop-conditions.md` "infra-red" case).
+- Non-empty `pending` → wait; use a scheduled wake-up, not busy-poll.
+
+## Get the PR's GraphQL node ID (used by mutations)
+
+```bash
+gh pr view "$PR_NUM" --repo "$REPO" --json id --jq .id
+```
+
+Format is `PR_xxxxxxxxxx...` — passed as `$prId` to mutations.
+
+## Failure modes
+
+### "Could not resolve to User node" on `requestReviews`
+
+You used `userIds: [...]` instead of `botIds: [...]`. Copilot is a bot.
+Fix the mutation:
+
+```diff
+- requestReviews(input: {pullRequestId: $prId, userIds: [$botId]})
++ requestReviews(input: {pullRequestId: $prId, botIds: [$botId]})
+```
+
+### `requestReviews` succeeds but no new review appears
+
+Possible causes, in order of likelihood:
+
+1. **No new commits on the PR since the last review.** Copilot
+   deduplicates. Push at least one commit (even a tiny doc fix)
+   between review requests.
+2. **Copilot reviewer disabled on the repo.** Settings → General →
+   Features → Copilot code review. Turn it on for the repo or org.
+3. **PR is in a draft state.** Copilot won't review draft PRs on
+   some configurations. Mark as ready for review.
+4. **Rate limit.** Rare but possible on very rapid review cycles.
+   Wait a minute and retry.
+
+### Comment replies are 404-ing on valid-looking IDs
+
+Use the `/comments/<id>/replies` endpoint (review-comment replies), not
+`/issues/comments/<id>` (issue comments). Inline PR comments are
+separate from issue-style comments; different API surfaces.
+
+### Batch reply shell loop prints huge GitHub response JSON
+
+Pipe to `| head -1` or `| jq -c '.id'` to squelch the verbose response.
+The reply succeeded if the response contains an `"id"` field; everything
+else is noise.
+
+## Further reading
+
+- [GitHub REST API: pull request review comments](https://docs.github.com/en/rest/pulls/comments)
+- [GitHub GraphQL: requestReviews mutation](https://docs.github.com/en/graphql/reference/mutations#requestreviews)
+- `gh api --help` for CLI flags

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -62,7 +62,7 @@ gh api graphql -f query='
   query($owner: String!, $name: String!, $number: Int!) {
     repository(owner: $owner, name: $name) {
       pullRequest(number: $number) {
-        reviews(first: 10) {
+        reviews(last: 20) {
           nodes {
             author {
               __typename
@@ -76,6 +76,11 @@ gh api graphql -f query='
   }' -F owner=<owner> -F name=<repo> -F number=<pr-with-copilot-review> \
   --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | {id, login}'
 ```
+
+`last: 20` pulls the 20 most recent reviews rather than the oldest
+20. On a PR that's been through many review cycles (especially
+multi-round loops), Copilot's reviews are near the end of the
+timeline; using `first:` without an `orderBy` can skip them.
 
 Any PR that has already been reviewed by Copilot will work. Save the
 resulting `id` as your `BOT_ID` for the `requestReviews` mutation.
@@ -132,9 +137,12 @@ if [ -z "$LAST_COPILOT" ]; then
   exit 1
 fi
 
-# Pull only top-level comments (not replies) newer than that timestamp
+# Pull only top-level comments (not replies) from the latest
+# review. Use `>=` not `>` so comments created in the same second
+# as the review's submittedAt (common since GitHub timestamps are
+# second-granular) don't get filtered out.
 gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?sort=created&direction=desc&per_page=100" --jq \
-  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at > \"$LAST_COPILOT\")] | .[] | {id, line, path, body: (.body[0:200])}"
+  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at >= \"$LAST_COPILOT\")] | .[] | {id, line, path, body: (.body[0:200])}"
 ```
 
 `in_reply_to_id == null` filters out Copilot's replies to your replies

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -35,10 +35,12 @@ or a future github.com where the ID has rotated.
 Use it in the `botIds` field of `requestReviews`. Do NOT pass it as
 `userIds` — Copilot is a bot, not a user, and userIds will 404.
 
-### Gotcha: the bot has three different login strings across APIs
+### Gotcha: Copilot's identifier across APIs
 
 Copilot's identifier is not consistent across GitHub's API surfaces.
-Three distinct values appear in the wild:
+Three distinct **login strings** appear depending on which endpoint
+you hit (plus a separate `user.type` field that's always `Bot` for
+account-shape disambiguation):
 
 | API endpoint | Field | Value |
 |---|---|---|
@@ -48,7 +50,7 @@ Three distinct values appear in the wild:
 | GraphQL `reviews.nodes[].author.login` | | `copilot-pull-request-reviewer` |
 | GraphQL `reviewThreads.nodes[].comments.nodes[].author.login` | | `copilot-pull-request-reviewer` |
 
-Match by endpoint:
+Match by endpoint when filtering:
 - REST comments → `"Copilot"`
 - REST reviews → `"copilot-pull-request-reviewer[bot]"` (note the `[bot]` suffix)
 - GraphQL anywhere → `"copilot-pull-request-reviewer"` (no suffix)

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -429,9 +429,12 @@ Possible causes, in order of likelihood:
 
 ### Comment replies are 404-ing on valid-looking IDs
 
-Use the `/comments/<id>/replies` endpoint (review-comment replies), not
-`/issues/comments/<id>` (issue comments). Inline PR comments are
-separate from issue-style comments; different API surfaces.
+Use the PR review-comment reply endpoint
+`POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`
+— note the `{pull_number}` in the path — not the issue-comments endpoint
+`/repos/{owner}/{repo}/issues/comments/{comment_id}` (which is for
+top-level issue-style comments). Inline PR review comments and
+issue-style comments live on different API surfaces.
 
 ### Batch reply shell loop prints huge GitHub response JSON
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -358,9 +358,9 @@ CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE) blocks merge.
 ```bash
 gh pr view "$PR_NUM" --repo "$REPO" --json statusCheckRollup --jq \
   '{
-     blocking: [.statusCheckRollup[] | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL") | {name, conclusion}],
-     pending: [.statusCheckRollup[] | select(.status != "COMPLETED") | .name],
-     green: ([.statusCheckRollup[] | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))] | length)
+     blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL") | {name, conclusion}],
+     pending: [.statusCheckRollup[]? | select(.status != "COMPLETED") | .name],
+     green: ([.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))] | length)
    }'
 ```
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -35,19 +35,24 @@ or a future github.com where the ID has rotated.
 Use it in the `botIds` field of `requestReviews`. Do NOT pass it as
 `userIds` — Copilot is a bot, not a user, and userIds will 404.
 
-### Gotcha: the bot has two different login strings across APIs
+### Gotcha: the bot has three different login strings across APIs
 
-Copilot's identifier is not consistent across GitHub's API surfaces:
+Copilot's identifier is not consistent across GitHub's API surfaces.
+Three distinct values appear in the wild:
 
 | API endpoint | Field | Value |
 |---|---|---|
 | REST `/pulls/<N>/comments` | `user.login` | `Copilot` |
 | REST `/pulls/<N>/comments` | `user.type` | `Bot` |
+| REST `/pulls/<N>/reviews` | `user.login` | `copilot-pull-request-reviewer[bot]` |
 | GraphQL `reviews.nodes[].author.login` | | `copilot-pull-request-reviewer` |
 | GraphQL `reviewThreads.nodes[].comments.nodes[].author.login` | | `copilot-pull-request-reviewer` |
 
-Filtering comments via REST: match `"Copilot"`.
-Filtering review threads via GraphQL: match `"copilot-pull-request-reviewer"`.
+Match by endpoint:
+- REST comments → `"Copilot"`
+- REST reviews → `"copilot-pull-request-reviewer[bot]"` (note the `[bot]` suffix)
+- GraphQL anywhere → `"copilot-pull-request-reviewer"` (no suffix)
+
 Getting this wrong silently returns an empty result — no error, just
 zero matches. Double-check with one unfiltered query first if your
 filter returns unexpectedly empty.
@@ -74,7 +79,7 @@ gh api graphql -f query='
       }
     }
   }' -F owner=<owner> -F name=<name> -F number=<pr-with-recent-copilot-review> \
-  --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | select(.author.login == "copilot-pull-request-reviewer") | {id, login}'
+  --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot") | select(.author.login == "copilot-pull-request-reviewer") | .author | {id, login}'
 ```
 
 `last: 50` pulls the 50 most recent reviews rather than the oldest
@@ -138,22 +143,30 @@ gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
 
 **Only Copilot's top-level comments from the latest round:**
 
-```bash
-# Find when the latest Copilot review was submitted
-LAST_COPILOT=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviews --jq \
-  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt // empty')
+Filter by `pull_request_review_id`, not by timestamp. Review comments
+on GitHub are created a second or two BEFORE the parent review's
+`submitted_at` (the comments exist during review composition; the
+review is finalised last). Timestamp comparisons like
+`created_at >= submitted_at` miss those earlier-by-a-second comments
+and return false "zero new findings" readings.
 
-if [ -z "$LAST_COPILOT" ]; then
+```bash
+# Get the latest Copilot review's integer ID from REST. Note the
+# REST-reviews endpoint uses "copilot-pull-request-reviewer[bot]"
+# (with a [bot] suffix) — different from the REST-comments "Copilot"
+# and the GraphQL "copilot-pull-request-reviewer".
+LAST_COPILOT_REVIEW_ID=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews?per_page=100" --jq \
+  '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last | .id // empty')
+
+if [ -z "$LAST_COPILOT_REVIEW_ID" ]; then
   echo "No Copilot review yet on this PR." >&2
   exit 1
 fi
 
-# Pull only top-level comments (not replies) from the latest
-# review. Use `>=` not `>` so comments created in the same second
-# as the review's submittedAt (common since GitHub timestamps are
-# second-granular) don't get filtered out.
-gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?sort=created&direction=desc&per_page=100" --jq \
-  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at >= \"$LAST_COPILOT\")] | .[] | {id, line, path, body: (.body[0:200])}"
+# Pull only top-level comments (not replies) that belong to that
+# specific review — the review-id match is exact, no timestamp race.
+gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
+  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.pull_request_review_id == $LAST_COPILOT_REVIEW_ID)] | .[] | {id, line, path, body: (.body[0:200])}"
 ```
 
 `in_reply_to_id == null` filters out Copilot's replies to your replies
@@ -295,8 +308,12 @@ UNRESOLVED=$(gh api graphql -f query='
   }' -F owner="$OWNER" -F name="$NAME" -F number="$PR_NUM" \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select([.comments.nodes[].author.login] | any(. == "'"$ME"'")) | .id')
 
-# 2. Resolve each
-for tid in $UNRESOLVED; do
+# 2. Resolve each. Use `while read` instead of unquoted `for` so
+# whitespace or newline-containing IDs can't trip the shell's word
+# splitting. Thread IDs don't contain whitespace today, but this is
+# defensive-by-default.
+while IFS= read -r tid; do
+  [ -z "$tid" ] && continue
   gh api graphql -f query='
     mutation($threadId: ID!) {
       resolveReviewThread(input: {threadId: $threadId}) {
@@ -304,7 +321,7 @@ for tid in $UNRESOLVED; do
       }
     }' -f threadId="$tid" >/dev/null
   echo "Resolved $tid"
-done
+done <<< "$UNRESOLVED"
 ```
 
 The filter `any(author == $ME)` limits resolution to threads YOU
@@ -333,21 +350,36 @@ against).
 
 ## Check CI status on the current PR head
 
+Whitelist-based: only `SUCCESS` and `SKIPPED` count as green; any
+other completed conclusion (FAILURE, CANCELLED, TIMED_OUT,
+ACTION_REQUIRED, STARTUP_FAILURE, NEUTRAL) blocks merge.
+
 ```bash
 gh pr view "$PR_NUM" --repo "$REPO" --json statusCheckRollup --jq \
   '{
-     failed: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name],
-     pending: [.statusCheckRollup[] | select(.status!="COMPLETED") | .name],
-     passing: ([.statusCheckRollup[] | select(.conclusion=="SUCCESS")] | length)
+     blocking: [.statusCheckRollup[] | select(.status == "COMPLETED" and (.conclusion != "SUCCESS" and .conclusion != "SKIPPED")) | {name, conclusion}],
+     pending: [.statusCheckRollup[] | select(.status != "COMPLETED") | .name],
+     green: ([.statusCheckRollup[] | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED"))] | length)
    }'
 ```
 
 Interpret:
 
-- Empty `failed`, empty `pending` → ready to consider merging.
-- Non-empty `failed` → investigate. If the same check also fails on
-  `main`, it's infra (see `stop-conditions.md` "infra-red" case).
+- Empty `blocking`, empty `pending` → every completed check is green
+  (SUCCESS or SKIPPED), nothing in-flight → ready to consider merging.
+- Non-empty `blocking` → investigate by conclusion. FAILURE means
+  fix the code or the workflow (infra if the same check also fails
+  on `main` — see `stop-conditions.md` "failure-mode stops"
+  section). CANCELLED / TIMED_OUT usually means re-run.
+  ACTION_REQUIRED usually means a first-time-contributor approval
+  or secret-access prompt.
 - Non-empty `pending` → wait; use a scheduled wake-up, not busy-poll.
+
+Why not a FAILURE-only filter: GitHub's check conclusions include
+CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, and NEUTRAL.
+A blacklist on FAILURE lets those slip through and falsely flags the
+PR as green when a required check was killed mid-run or is waiting
+on manual intervention.
 
 ## Get the PR's GraphQL node ID (used by mutations)
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -158,9 +158,15 @@ thread has an `isResolved` flag that drives the PR's "unresolved
 conversations" counter. To work with thread resolution you need the
 thread ID (not the comment ID).
 
+Variable convention for this file: `REPO=<owner>/<repo>` for REST
+endpoints (`repos/$REPO/...`), and `OWNER=<owner>` + `NAME=<repo>`
+as two separate fields for GraphQL `repository(owner:, name:)`
+queries. Don't reuse `REPO` as the bare-name GraphQL variable —
+copy/paste across sections will break.
+
 ```bash
 OWNER=<owner>
-REPO=<repo>
+NAME=<repo>
 PR_NUM=<pr-number>
 
 gh api graphql -f query='
@@ -182,7 +188,7 @@ gh api graphql -f query='
         }
       }
     }
-  }' -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUM" \
+  }' -F owner="$OWNER" -F name="$NAME" -F number="$PR_NUM" \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[] | {id, isResolved, first_author: .comments.nodes[0].author.login, first_body: .comments.nodes[0].body[0:100]}'
 ```
 
@@ -228,7 +234,7 @@ Common case after a round of fixes: you've replied to 6 threads
 with apply SHAs, now you want to resolve them all in one shot.
 
 ```bash
-OWNER=<owner>; REPO=<repo>; PR_NUM=<N>; ME=<your-github-login>
+OWNER=<owner>; NAME=<repo>; PR_NUM=<N>; ME=<your-github-login>
 
 # 1. Get all unresolved threads
 UNRESOLVED=$(gh api graphql -f query='
@@ -240,7 +246,7 @@ UNRESOLVED=$(gh api graphql -f query='
         }
       }
     }
-  }' -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUM" \
+  }' -F owner="$OWNER" -F name="$NAME" -F number="$PR_NUM" \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select([.comments.nodes[].author.login] | any(. == "'"$ME"'")) | .id')
 
 # 2. Resolve each

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -19,9 +19,8 @@ API. All shell-safe; all assume `gh` is authenticated.
 
 ## Copilot's bot ID
 
-On github.com, Copilot's PR reviewer is a `Bot` account (REST
-`user.type = "Bot"`, `user.login = "Copilot"`) with this global node
-ID:
+On github.com, Copilot's PR reviewer is a `Bot` account with this
+global node ID:
 
 ```
 BOT_kgDOCnlnWA
@@ -35,6 +34,23 @@ or a future github.com where the ID has rotated.
 
 Use it in the `botIds` field of `requestReviews`. Do NOT pass it as
 `userIds` — Copilot is a bot, not a user, and userIds will 404.
+
+### Gotcha: the bot has two different login strings across APIs
+
+Copilot's identifier is not consistent across GitHub's API surfaces:
+
+| API endpoint | Field | Value |
+|---|---|---|
+| REST `/pulls/<N>/comments` | `user.login` | `Copilot` |
+| REST `/pulls/<N>/comments` | `user.type` | `Bot` |
+| GraphQL `reviews.nodes[].author.login` | | `copilot-pull-request-reviewer` |
+| GraphQL `reviewThreads.nodes[].comments.nodes[].author.login` | | `copilot-pull-request-reviewer` |
+
+Filtering comments via REST: match `"Copilot"`.
+Filtering review threads via GraphQL: match `"copilot-pull-request-reviewer"`.
+Getting this wrong silently returns an empty result — no error, just
+zero matches. Double-check with one unfiltered query first if your
+filter returns unexpectedly empty.
 
 ### Discovering the bot ID at runtime
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -350,23 +350,25 @@ against).
 
 ## Check CI status on the current PR head
 
-Whitelist-based: only `SUCCESS` and `SKIPPED` count as green; any
-other completed conclusion (FAILURE, CANCELLED, TIMED_OUT,
-ACTION_REQUIRED, STARTUP_FAILURE, NEUTRAL) blocks merge.
+Whitelist-based: `SUCCESS`, `SKIPPED`, and `NEUTRAL` count as green
+(matches GitHub's own merge gate — NEUTRAL is treated as success for
+required checks). Any other completed conclusion (FAILURE,
+CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE) blocks merge.
 
 ```bash
 gh pr view "$PR_NUM" --repo "$REPO" --json statusCheckRollup --jq \
   '{
-     blocking: [.statusCheckRollup[] | select(.status == "COMPLETED" and (.conclusion != "SUCCESS" and .conclusion != "SKIPPED")) | {name, conclusion}],
+     blocking: [.statusCheckRollup[] | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL") | {name, conclusion}],
      pending: [.statusCheckRollup[] | select(.status != "COMPLETED") | .name],
-     green: ([.statusCheckRollup[] | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED"))] | length)
+     green: ([.statusCheckRollup[] | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))] | length)
    }'
 ```
 
 Interpret:
 
 - Empty `blocking`, empty `pending` → every completed check is green
-  (SUCCESS or SKIPPED), nothing in-flight → ready to consider merging.
+  (SUCCESS, SKIPPED, or NEUTRAL), nothing in-flight → ready to
+  consider merging.
 - Non-empty `blocking` → investigate by conclusion. FAILURE means
   fix the code or the workflow (infra if the same check also fails
   on `main` — see `stop-conditions.md` "failure-mode stops"
@@ -376,10 +378,16 @@ Interpret:
 - Non-empty `pending` → wait; use a scheduled wake-up, not busy-poll.
 
 Why not a FAILURE-only filter: GitHub's check conclusions include
-CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, and NEUTRAL.
-A blacklist on FAILURE lets those slip through and falsely flags the
+CANCELLED, TIMED_OUT, ACTION_REQUIRED, and STARTUP_FAILURE. A
+blacklist on FAILURE lets those slip through and falsely flags the
 PR as green when a required check was killed mid-run or is waiting
 on manual intervention.
+
+Why NEUTRAL is in the green set: GitHub's required-status-check and
+dependent-check logic both treat NEUTRAL as a passing outcome.
+Tools (linters, code-scanners) that want to signal "I ran and found
+nothing actionable" use NEUTRAL rather than SUCCESS. Treating it as
+blocking would be stricter than GitHub's own merge gate.
 
 ## Get the PR's GraphQL node ID (used by mutations)
 

--- a/skills/github-pr-review-loop/references/graphql-snippets.md
+++ b/skills/github-pr-review-loop/references/graphql-snippets.md
@@ -33,7 +33,9 @@ helper below for anyone on GitHub Enterprise, a different instance,
 or a future github.com where the ID has rotated.
 
 Use it in the `botIds` field of `requestReviews`. Do NOT pass it as
-`userIds` — Copilot is a bot, not a user, and userIds will 404.
+`userIds` — Copilot is a bot, not a user, and the mutation typically
+returns a GraphQL error (often still HTTP 200) like `Could not
+resolve to User node` rather than a 404.
 
 ### Gotcha: Copilot's identifier across APIs
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -120,15 +120,32 @@ gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
 
 If that count is 0 AND the review's `submitted_at`
 (`$LAST_COPILOT_REVIEW_AT`) is newer than your most recent commit's
-author date, the latest pass was actually clean. The ID itself is a
-monotonically-increasing integer, so comparing IDs to a commit would
-be a type error; the timestamp is what's actually comparable.
+**committer** date, the latest pass was actually clean.
+
+```bash
+LATEST_COMMIT_DATE=$(git -C "$REPO_DIR" log -1 --format=%cI HEAD)
+# then:  "$LAST_COPILOT_REVIEW_AT" > "$LATEST_COMMIT_DATE"  (ISO-8601 string
+# compare works correctly)
+```
+
+Why committer date and not author date: author date is preserved
+across rebase / cherry-pick / am-patch, so it can be arbitrarily old
+for a commit that just landed on the branch. Copilot still reviews
+the head at its current committer time, so comparing to the author
+date can mark a fresh review as "stale" and chase a false failure.
+The committer date is updated on every git operation that writes
+the commit, which is what you actually care about.
+
+The review ID itself is a monotonically-increasing integer, so
+comparing IDs to a commit would be a type error; the timestamp is
+what's actually comparable.
 
 Caveats:
 
 - The count can be 0 because Copilot hasn't reviewed since your last
   push. Check the review's `submitted_at` is newer than your most
-  recent commit's timestamp before trusting the zero.
+  recent commit's **committer** date (`git log -1 --format=%cI HEAD`)
+  before trusting the zero.
 - `LAST_COPILOT_REVIEW_ID` is empty when no Copilot review has ever
   run on the PR. The guard above treats that as "not ready" rather
   than "clean" — don't interpret silence as consent.
@@ -145,10 +162,15 @@ engaged with has been resolved. A PR with 0 new findings AND 0
 unresolved threads is the cleanest merge state.
 
 Placeholder note: `<owner>` is the org/user, `<name>` is the bare
-repo name. Elsewhere in this doc `<owner>/<repo>` is the combined
-slug passed to REST endpoints; GraphQL's `repository(owner:, name:)`
-takes them as two separate fields, so this block uses `<name>`
-deliberately.
+repo name. Earlier blocks in this doc used `REPO="<owner>/<repo>"` —
+the combined slug for REST endpoints. GraphQL's
+`repository(owner:, name:)` takes them as two separate fields, so
+this block needs two shell vars:
+
+```bash
+OWNER="<owner>"          # e.g. qubitrenegade
+NAME="<name>"            # bare repo name, e.g. github-pr-review-loop
+```
 
 ```bash
 # reviewThreads(first: 100) returns at most 100 threads — fine for

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -32,8 +32,17 @@ Use a whitelist (SUCCESS, SKIPPED, NEUTRAL are the green
 conclusions), not a blacklist (FAILURE alone misses CANCELLED,
 TIMED_OUT, etc. and falsely green-lights a broken gate).
 
+Set env vars first so the snippets are copy-paste-safe (angle-bracket
+placeholders like `<N>` are I/O redirection tokens in bash/zsh even
+inside assignments; quote them on the RHS):
+
 ```bash
-gh pr view <N> --repo <owner>/<repo> --json statusCheckRollup --jq \
+REPO="<owner>/<repo>"    # e.g. qubitrenegade/github-pr-review-loop
+PR_NUM="<N>"             # e.g. 42
+```
+
+```bash
+gh pr view "$PR_NUM" --repo "$REPO" --json statusCheckRollup --jq \
   '{
     blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL") | {name, conclusion}],
     pending: [.statusCheckRollup[]? | select(.status != "COMPLETED") | .name],
@@ -73,8 +82,8 @@ is finalised last) — timestamp filters silently miss those and read
 as false "clean" passes.
 
 ```bash
-REPO=<owner>/<repo>
-PR_NUM=<N>
+REPO="<owner>/<repo>"
+PR_NUM="<N>"
 
 # Get the latest Copilot review's ID AND submitted_at in one fetch.
 # The REST reviews endpoint exposes Copilot's login as
@@ -156,7 +165,7 @@ gh api graphql -f query='
         }
       }
     }
-  }' -F owner=<owner> -F name=<name> -F number=<N> \
+  }' -F owner="$OWNER" -F name="$NAME" -F number="$PR_NUM" \
   --jq '{
     total: .data.repository.pullRequest.reviewThreads.totalCount,
     sampled: (.data.repository.pullRequest.reviewThreads.nodes | length),

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -123,7 +123,10 @@ If that count is 0 AND the review's `submitted_at`
 **committer** date, the latest pass was actually clean.
 
 ```bash
-LATEST_COMMIT_DATE=$(git -C "$REPO_DIR" log -1 --format=%cI HEAD)
+# Run from inside the checkout of $REPO, or set REPO_DIR to the
+# local path (REPO_DIR="<local-path-to-clone>"; then
+# git -C "$REPO_DIR" ...).
+LATEST_COMMIT_DATE=$(git log -1 --format=%cI HEAD)
 # then:  "$LAST_COPILOT_REVIEW_AT" > "$LATEST_COMMIT_DATE"  (ISO-8601 string
 # compare works correctly)
 ```
@@ -165,11 +168,14 @@ Placeholder note: `<owner>` is the org/user, `<name>` is the bare
 repo name. Earlier blocks in this doc used `REPO="<owner>/<repo>"` —
 the combined slug for REST endpoints. GraphQL's
 `repository(owner:, name:)` takes them as two separate fields, so
-this block needs two shell vars:
+this block needs three shell vars (the PR number is also referenced
+below):
 
 ```bash
 OWNER="<owner>"          # e.g. qubitrenegade
 NAME="<name>"            # bare repo name, e.g. github-pr-review-loop
+PR_NUM="<N>"             # e.g. 42 — same value as the REST sections'
+                         # PR_NUM if you're running from the same shell
 ```
 
 ```bash

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -14,6 +14,7 @@ arbitrary thresholds.
 - User escape hatch
 - Failure-mode stops
 - Anti-patterns (don't stop for these reasons)
+- Putting it together
 
 ## Merge precondition: required CI checks are green
 
@@ -75,16 +76,21 @@ as false "clean" passes.
 REPO=<owner>/<repo>
 PR_NUM=<N>
 
-# Get the latest Copilot review's integer ID from REST. The REST
-# reviews endpoint exposes Copilot's login as
+# Get the latest Copilot review's ID AND submitted_at in one fetch.
+# The REST reviews endpoint exposes Copilot's login as
 # "copilot-pull-request-reviewer[bot]" (with the [bot] suffix) —
 # which differs from the REST comments "Copilot" and the GraphQL
 # "copilot-pull-request-reviewer". See graphql-snippets.md gotcha
 # table.
-LAST_COPILOT_REVIEW_ID=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews?per_page=100" --jq \
-  '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last | .id // empty')
+#
+# `read` with a tab separator keeps both fields in scope for the
+# cross-check further down without requiring a second API call.
+read -r LAST_COPILOT_REVIEW_ID LAST_COPILOT_REVIEW_AT < <(
+  gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews?per_page=100" --jq \
+    '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last | "\(.id)\t\(.submitted_at)" // empty'
+)
 
-# Guard: if Copilot has never reviewed this PR, the ID is empty.
+# Guard: if Copilot has never reviewed this PR, both fields are empty.
 # That is not a "clean pass" — it just means the reviewer hasn't
 # run yet. Fall back to an explicit "no reviews" signal so the rest
 # of the loop doesn't treat missing data as success.
@@ -99,10 +105,11 @@ gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
   "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.pull_request_review_id == $LAST_COPILOT_REVIEW_ID)] | length"
 ```
 
-If that count is 0 AND the `LAST_COPILOT_REVIEW_ID` is newer than
-your most recent commit (you can cross-check with the review's
-`submitted_at` from the same REST fetch), the latest pass was
-actually clean.
+If that count is 0 AND the review's `submitted_at`
+(`$LAST_COPILOT_REVIEW_AT`) is newer than your most recent commit's
+author date, the latest pass was actually clean. The ID itself is a
+monotonically-increasing integer, so comparing IDs to a commit would
+be a type error; the timestamp is what's actually comparable.
 
 Caveats:
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -19,27 +19,37 @@ arbitrary thresholds.
 
 Before any stop condition becomes a merge decision, **every required
 CI check on the PR head must be in `SUCCESS` (or `SKIPPED`) state.**
-A clean Copilot pass on red CI is not a merge — it's permission to
+Any other conclusion blocks merge — FAILURE, CANCELLED, TIMED_OUT,
+ACTION_REQUIRED, STARTUP_FAILURE, NEUTRAL, or still in-progress. A
+clean Copilot pass on red CI is not a merge — it's permission to
 stop chasing review comments while the CI problem still needs
 solving.
 
+Use a whitelist (SUCCESS/SKIPPED are the only green conclusions),
+not a blacklist (FAILURE alone misses CANCELLED, TIMED_OUT, etc. and
+falsely green-lights a broken gate).
+
 ```bash
 gh pr view <N> --repo <owner>/<repo> --json statusCheckRollup --jq \
-  '{failed: [.statusCheckRollup[]? | select(.conclusion=="FAILURE") | .name],
-    pending: [.statusCheckRollup[]? | select(.status!="COMPLETED") | .name],
-    passing: ([.statusCheckRollup[]? | select(.conclusion=="SUCCESS")] | length)}'
+  '{
+    blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion != "SUCCESS" and .conclusion != "SKIPPED")) | {name, conclusion}],
+    pending: [.statusCheckRollup[]? | select(.status != "COMPLETED") | .name],
+    green: ([.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED"))] | length)
+  }'
 ```
 
 **Interpret:**
 
-- `failed == [] && pending == []` → CI is green, merge gate is
-  clear.
-- `failed != []` → investigate. Two cases:
-  - Failure is specific to this PR's diff → fix it (code, test, or
-    workflow in the same PR).
-  - Failure reproduces on `main` unchanged → pre-existing infra
-    breakage. Fix the infra in a dedicated PR, merge that, then CI
-    on this PR should go green. DO NOT admin-merge past it.
+- `blocking == [] && pending == []` → every completed check is
+  SUCCESS or SKIPPED, nothing in-flight → CI gate is clear.
+- `blocking != []` → investigate by conclusion. Every non-SUCCESS /
+  non-SKIPPED completed conclusion blocks merge. FAILURE means the
+  code or workflow is broken — if the failure reproduces on `main`
+  unchanged it's pre-existing infra (fix it in a dedicated PR, DO
+  NOT admin-merge past). CANCELLED / TIMED_OUT / STARTUP_FAILURE
+  usually means re-run. ACTION_REQUIRED usually means a
+  first-time-contributor approval or a secret-access prompt. NEUTRAL
+  is rare — treat as block-and-investigate.
 - `pending != []` → wait. Don't merge mid-CI. Schedule another
   wake-up.
 
@@ -53,40 +63,58 @@ on main → fix the infra first, don't bypass".
 latest head and produced no new inline comments. Any existing threads
 are replies-to-previously-addressed findings, not fresh signal.
 
-Check empirically:
+Check empirically by filtering comments on their
+`pull_request_review_id`, not on a timestamp comparison. Review-
+comment `created_at` can precede the parent review's `submitted_at`
+by a second or two (comments exist during composition; the review
+is finalised last) — timestamp filters silently miss those and read
+as false "clean" passes.
 
 ```bash
-# When did the latest Copilot review submit?
-LAST=$(gh pr view <N> --repo <owner>/<repo> --json reviews --jq \
-  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt // empty')
+REPO=<owner>/<repo>
+PR_NUM=<N>
 
-# Guard: if Copilot has never reviewed this PR, LAST is empty. That
-# is not a "clean pass" — it just means the reviewer hasn't run yet.
-# Fall back to an explicit "no reviews" signal so the rest of the
-# loop doesn't treat missing data as success.
-if [ -z "$LAST" ]; then
+# Get the latest Copilot review's integer ID from REST. The REST
+# reviews endpoint exposes Copilot's login as
+# "copilot-pull-request-reviewer[bot]" (with the [bot] suffix) —
+# which differs from the REST comments "Copilot" and the GraphQL
+# "copilot-pull-request-reviewer". See graphql-snippets.md gotcha
+# table.
+LAST_COPILOT_REVIEW_ID=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews?per_page=100" --jq \
+  '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last | .id // empty')
+
+# Guard: if Copilot has never reviewed this PR, the ID is empty.
+# That is not a "clean pass" — it just means the reviewer hasn't
+# run yet. Fall back to an explicit "no reviews" signal so the rest
+# of the loop doesn't treat missing data as success.
+if [ -z "$LAST_COPILOT_REVIEW_ID" ]; then
   echo "No Copilot review yet — request one (or wait)." >&2
   exit 1
 fi
 
-# Count top-level inline comments created at or after that timestamp.
-# --paginate pulls every page so large PRs don't silently truncate at
-# 100 comments.
-gh api --paginate "repos/<owner>/<repo>/pulls/<N>/comments?per_page=100" --jq \
-  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at >= \"$LAST\")] | length"
+# Count top-level inline comments belonging to that specific review.
+# --paginate pulls every page so large PRs don't silently truncate.
+gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq \
+  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.pull_request_review_id == $LAST_COPILOT_REVIEW_ID)] | length"
 ```
 
-If that count is 0 AND `LAST` is newer than your most recent commit's
-timestamp, the latest pass was actually clean.
+If that count is 0 AND the `LAST_COPILOT_REVIEW_ID` is newer than
+your most recent commit (you can cross-check with the review's
+`submitted_at` from the same REST fetch), the latest pass was
+actually clean.
 
 Caveats:
 
 - The count can be 0 because Copilot hasn't reviewed since your last
-  push. Confirm `LAST` is newer than your most recent commit's
-  timestamp before trusting the zero.
-- `LAST` is empty when no Copilot review has ever run on the PR. The
-  guard above treats that as "not ready" rather than "clean" — don't
-  interpret silence as consent.
+  push. Check the review's `submitted_at` is newer than your most
+  recent commit's timestamp before trusting the zero.
+- `LAST_COPILOT_REVIEW_ID` is empty when no Copilot review has ever
+  run on the PR. The guard above treats that as "not ready" rather
+  than "clean" — don't interpret silence as consent.
+- Do NOT filter by `created_at >= submitted_at`. Empirically
+  confirmed: inline comments on a Copilot review can have
+  timestamps 1-2 seconds BEFORE the review's `submitted_at`, so a
+  `>=` filter drops them. Use `pull_request_review_id` instead.
 
 ## Complement: zero unresolved conversation threads
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -96,22 +96,37 @@ engaged with has been resolved. A PR with 0 new findings AND 0
 unresolved threads is the cleanest merge state.
 
 ```bash
+# reviewThreads(first: 100) returns at most 100 threads — fine for
+# ordinary PRs but silently undercounts on PRs with more than that.
+# totalCount gives the exact number so we can sanity-check before
+# relying on the isResolved-filter result.
 gh api graphql -f query='
   query($owner: String!, $name: String!, $number: Int!) {
     repository(owner: $owner, name: $name) {
       pullRequest(number: $number) {
         reviewThreads(first: 100) {
+          totalCount
           nodes { isResolved }
         }
       }
     }
   }' -F owner=<owner> -F name=<repo> -F number=<N> \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+  --jq '{
+    total: .data.repository.pullRequest.reviewThreads.totalCount,
+    sampled: (.data.repository.pullRequest.reviewThreads.nodes | length),
+    unresolved: ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length)
+  }'
 ```
 
-Zero here means every thread on the PR has been explicitly closed
-(fixed, dismissed with evidence, deferred with issue, or clarified
-+ acted on). Humans skimming the PR can trust that nothing slipped.
+If `total > sampled` (over 100 threads on the PR), paginate via
+`pageInfo.endCursor` + `after:` before trusting the unresolved
+count — see the pagination note in
+[graphql-snippets.md](graphql-snippets.md).
+
+Zero unresolved (when `total == sampled`) means every thread on the
+PR has been explicitly closed (fixed, dismissed with evidence,
+deferred with issue, or clarified + acted on). Humans skimming the
+PR can trust that nothing slipped.
 
 If this count is >0 but the "new findings" count is 0, you have
 open threads you didn't resolve. Either resolve them now (if they

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -1,0 +1,144 @@
+# Stop conditions
+
+When to stop chasing a Copilot review loop. Concrete signals, not
+arbitrary thresholds.
+
+## Contents
+
+- Primary stop: zero new findings on a Copilot pass
+- Secondary stop: Copilot repeats itself
+- Tertiary stop: suggestion volume dries up
+- User escape hatch
+- Failure-mode stops
+- Anti-patterns (don't stop for these reasons)
+
+## Primary stop: zero new findings
+
+**The most reliable signal.** Copilot completed a review pass on the
+latest head and produced no new inline comments. Any existing threads
+are replies-to-previously-addressed findings, not fresh signal.
+
+Check empirically:
+
+```bash
+# When did the latest Copilot review submit?
+LAST=$(gh pr view <N> --repo <repo> --json reviews --jq \
+  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt')
+
+# Count top-level inline comments created at or after that timestamp
+gh api "repos/<repo>/pulls/<N>/comments?per_page=100" --jq \
+  "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at >= \"$LAST\")] | length"
+```
+
+If that count is 0, the latest pass was clean. Merge when you're ready.
+
+Caveat: the count can be 0 because Copilot hasn't actually reviewed
+since your last push. Confirm `LAST` is newer than your most recent
+commit's timestamp before trusting the zero.
+
+## Secondary stop: Copilot repeats itself
+
+A new comment is substantively the same as one you already addressed
+(with a commit SHA or an evidence-backed dismissal). This happens
+periodically — the model's context for the PR gets re-initialised and
+it re-surfaces earlier findings.
+
+Reply once, pointing at the original thread:
+
+> Already addressed in `abc1234` (see earlier thread
+> [link-to-first-reply]). No code change needed.
+
+Do NOT change code to silence a repeated finding. That's how you end
+up on round 8 fixing the same doc sentence three different ways.
+
+After posting one "already addressed" reply per repeat, consider the
+reviewer out of fresh signal and merge when the rest of the thread is
+clean.
+
+## Tertiary stop: volume drying up
+
+Round 1: 7 findings. Round 2: 4. Round 3: 2. Round 4: 1 minor nit.
+Round 5 is usually empty. If the volume is halving each round and the
+remaining comments are stylistic or repeat-adjacent, the reviewer has
+said what it was going to say.
+
+Graph the count over rounds. If the curve flattens into the noise
+floor (0-1 low-value comments per round), stop.
+
+This is different from "ignore round-4+ comments". Every comment still
+gets triaged (apply / dismiss / clarify). The stop decision is about
+whether to wait for another round, not whether to process comments
+already on the PR.
+
+## User escape hatch
+
+If the human maintainer says "merge it", that overrides every other
+signal. They have context you don't — maybe there's a release cutoff,
+maybe the remaining comments are known non-issues, maybe they've
+reviewed inline and are satisfied.
+
+When the user says merge, merge. Don't re-litigate.
+
+## Failure-mode stops
+
+These are "stop and escalate" signals, not clean completions.
+
+**Copilot is hallucinating at high volume.** Three or more consecutive
+findings that verify false under the evidence check. The reviewer has
+gone off the rails for this PR; flag it to the maintainer and propose
+merging on human review only.
+
+**The thread has devolved.** Comments are rephrasings of already-closed
+threads, or suggestions that contradict comments from earlier rounds,
+or style preferences stated with confidence but no supporting rule.
+Flag, don't fix.
+
+**CI is red for reasons unrelated to the PR's diff.** If the same
+failure reproduces on `main`, it's pre-existing infra. Don't keep
+force-pushing attempts to fix it in the PR; file or fix the infra
+issue in its own PR, merge that first, rebase this PR, continue.
+
+**A high-stakes "must fix" from Copilot that you can't verify.** If
+Copilot says "this will leak secrets" or "this will crash in
+production" and you can't confirm or refute after genuine
+investigation, stop and ask the maintainer before merging. Don't merge
+on hope.
+
+## Anti-patterns — don't stop for these reasons
+
+**"I've done N rounds, that feels like enough."** Round count isn't
+the signal. Content is. If round 7 is still surfacing real issues,
+keep going. If round 2 came back clean, stop.
+
+**"The remaining comments are just style."** Real style violations
+are real issues. The project has a style for a reason. Dismiss only
+with evidence that the rule doesn't apply to the specific case, not
+because style is "just" anything.
+
+**"Copilot said this already."** Verify. Copilot sometimes surfaces a
+subtle variant of an earlier finding — the surface is the same, the
+underlying issue is different. Read before concluding "repeat".
+
+**"The PR is taking too long."** Quality over speed, but also: if the
+loop has been on for an hour+ and keeps surfacing real issues, the
+root cause might be that the PR is too large. Consider splitting.
+
+**"Admin merge will skip the remaining checks."** Only if you're
+intentionally shipping unreviewed code. Don't admin-merge to "save
+time" on review feedback; you just moved the review into the reports
+that will follow.
+
+## Putting it together
+
+The stop decision is: "has the reviewer told me what it has to tell
+me, and have I acted on it?"
+
+- Zero new comments on the latest pass → yes and yes → merge.
+- New comments are repeats of addressed threads → yes and yes (action
+  was the earlier fix) → merge.
+- Volume trending to zero with remaining comments being stylistic →
+  usually yes and yes → merge after processing the nits.
+- User says merge → yes → merge.
+
+If none of those fire and the reviewer is still producing signal, run
+another round.

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -239,8 +239,10 @@ me, and have I acted on it?"
 - Zero new comments on the latest pass → yes and yes → merge.
 - New comments are repeats of addressed threads → yes and yes (action
   was the earlier fix) → merge.
-- Volume trending to zero with remaining comments being stylistic →
-  usually yes and yes → merge after processing the nits.
+- Volume trending to zero, and each remaining comment has been
+  triaged under the usual apply/dismiss/clarify/defer → yes and
+  yes → merge. Triage the nits the same way as any other finding;
+  don't skip them because they're small.
 - User says merge → yes → merge.
 
 If none of those fire and the reviewer is still producing signal, run

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -1,10 +1,12 @@
 # Stop conditions
 
-When to stop chasing a Copilot review loop. Concrete signals, not
+When to stop chasing a Copilot review loop, and the merge gate that
+still has to clear before you actually merge. Concrete signals, not
 arbitrary thresholds.
 
 ## Contents
 
+- Merge precondition: required CI checks are green
 - Primary stop: zero new findings on a Copilot pass
 - Complement: zero unresolved conversation threads
 - Secondary stop: Copilot repeats itself
@@ -12,6 +14,38 @@ arbitrary thresholds.
 - User escape hatch
 - Failure-mode stops
 - Anti-patterns (don't stop for these reasons)
+
+## Merge precondition: required CI checks are green
+
+Before any stop condition becomes a merge decision, **every required
+CI check on the PR head must be in `SUCCESS` (or `SKIPPED`) state.**
+A clean Copilot pass on red CI is not a merge — it's permission to
+stop chasing review comments while the CI problem still needs
+solving.
+
+```bash
+gh pr view <N> --repo <owner>/<repo> --json statusCheckRollup --jq \
+  '{failed: [.statusCheckRollup[]? | select(.conclusion=="FAILURE") | .name],
+    pending: [.statusCheckRollup[]? | select(.status!="COMPLETED") | .name],
+    passing: ([.statusCheckRollup[]? | select(.conclusion=="SUCCESS")] | length)}'
+```
+
+**Interpret:**
+
+- `failed == [] && pending == []` → CI is green, merge gate is
+  clear.
+- `failed != []` → investigate. Two cases:
+  - Failure is specific to this PR's diff → fix it (code, test, or
+    workflow in the same PR).
+  - Failure reproduces on `main` unchanged → pre-existing infra
+    breakage. Fix the infra in a dedicated PR, merge that, then CI
+    on this PR should go green. DO NOT admin-merge past it.
+- `pending != []` → wait. Don't merge mid-CI. Schedule another
+  wake-up.
+
+See [case-study-clickwork-1.0.md](case-study-clickwork-1.0.md) for
+the Release-smoke episode — concrete example of "failure reproduces
+on main → fix the infra first, don't bypass".
 
 ## Primary stop: zero new findings
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -58,18 +58,35 @@ Check empirically:
 ```bash
 # When did the latest Copilot review submit?
 LAST=$(gh pr view <N> --repo <owner>/<repo> --json reviews --jq \
-  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt')
+  '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt // empty')
 
-# Count top-level inline comments created at or after that timestamp
-gh api "repos/<owner>/<repo>/pulls/<N>/comments?per_page=100" --jq \
+# Guard: if Copilot has never reviewed this PR, LAST is empty. That
+# is not a "clean pass" — it just means the reviewer hasn't run yet.
+# Fall back to an explicit "no reviews" signal so the rest of the
+# loop doesn't treat missing data as success.
+if [ -z "$LAST" ]; then
+  echo "No Copilot review yet — request one (or wait)." >&2
+  exit 1
+fi
+
+# Count top-level inline comments created at or after that timestamp.
+# --paginate pulls every page so large PRs don't silently truncate at
+# 100 comments.
+gh api --paginate "repos/<owner>/<repo>/pulls/<N>/comments?per_page=100" --jq \
   "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at >= \"$LAST\")] | length"
 ```
 
-If that count is 0, the latest pass was clean. Merge when you're ready.
+If that count is 0 AND `LAST` is newer than your most recent commit's
+timestamp, the latest pass was actually clean.
 
-Caveat: the count can be 0 because Copilot hasn't actually reviewed
-since your last push. Confirm `LAST` is newer than your most recent
-commit's timestamp before trusting the zero.
+Caveats:
+
+- The count can be 0 because Copilot hasn't reviewed since your last
+  push. Confirm `LAST` is newer than your most recent commit's
+  timestamp before trusting the zero.
+- `LAST` is empty when no Copilot review has ever run on the PR. The
+  guard above treats that as "not ready" rather than "clean" — don't
+  interpret silence as consent.
 
 ## Complement: zero unresolved conversation threads
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -86,8 +86,12 @@ PR_NUM=<N>
 # `read` with a tab separator keeps both fields in scope for the
 # cross-check further down without requiring a second API call.
 read -r LAST_COPILOT_REVIEW_ID LAST_COPILOT_REVIEW_AT < <(
+  # `last? | select(.)` short-circuits on an empty filtered array so the
+  # jq pipeline emits nothing (not the literal string "null") when Copilot
+  # hasn't reviewed yet. Without the guard, `"\(.id)\t\(.submitted_at)"`
+  # would interpolate null into a string, bypassing the -z check below.
   gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews?per_page=100" --jq \
-    '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last | "\(.id)\t\(.submitted_at)" // empty'
+    '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last? | select(.) | "\(.id)\t\(.submitted_at)"'
 )
 
 # Guard: if Copilot has never reviewed this PR, both fields are empty.

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -57,11 +57,11 @@ Check empirically:
 
 ```bash
 # When did the latest Copilot review submit?
-LAST=$(gh pr view <N> --repo <repo> --json reviews --jq \
+LAST=$(gh pr view <N> --repo <owner>/<repo> --json reviews --jq \
   '[.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | last | .submittedAt')
 
 # Count top-level inline comments created at or after that timestamp
-gh api "repos/<repo>/pulls/<N>/comments?per_page=100" --jq \
+gh api "repos/<owner>/<repo>/pulls/<N>/comments?per_page=100" --jq \
   "[.[] | select(.user.login==\"Copilot\") | select(.in_reply_to_id==null) | select(.created_at >= \"$LAST\")] | length"
 ```
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -95,6 +95,12 @@ complementary signal is about OUTGOING ones: every thread you
 engaged with has been resolved. A PR with 0 new findings AND 0
 unresolved threads is the cleanest merge state.
 
+Placeholder note: `<owner>` is the org/user, `<name>` is the bare
+repo name. Elsewhere in this doc `<owner>/<repo>` is the combined
+slug passed to REST endpoints; GraphQL's `repository(owner:, name:)`
+takes them as two separate fields, so this block uses `<name>`
+deliberately.
+
 ```bash
 # reviewThreads(first: 100) returns at most 100 threads — fine for
 # ordinary PRs but silently undercounts on PRs with more than that.
@@ -110,7 +116,7 @@ gh api graphql -f query='
         }
       }
     }
-  }' -F owner=<owner> -F name=<repo> -F number=<N> \
+  }' -F owner=<owner> -F name=<name> -F number=<N> \
   --jq '{
     total: .data.repository.pullRequest.reviewThreads.totalCount,
     sampled: (.data.repository.pullRequest.reviewThreads.nodes | length),
@@ -163,7 +169,7 @@ Graph the count over rounds. If the curve flattens into the noise
 floor (0-1 low-value comments per round), stop.
 
 This is different from "ignore round-4+ comments". Every comment still
-gets triaged (apply / dismiss / clarify). The stop decision is about
+gets triaged (apply / dismiss / clarify / defer). The stop decision is about
 whether to wait for another round, not whether to process comments
 already on the PR.
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -6,6 +6,7 @@ arbitrary thresholds.
 ## Contents
 
 - Primary stop: zero new findings on a Copilot pass
+- Complement: zero unresolved conversation threads
 - Secondary stop: Copilot repeats itself
 - Tertiary stop: suggestion volume dries up
 - User escape hatch
@@ -35,6 +36,36 @@ If that count is 0, the latest pass was clean. Merge when you're ready.
 Caveat: the count can be 0 because Copilot hasn't actually reviewed
 since your last push. Confirm `LAST` is newer than your most recent
 commit's timestamp before trusting the zero.
+
+## Complement: zero unresolved conversation threads
+
+The "zero new comments" signal is about INCOMING findings. The
+complementary signal is about OUTGOING ones: every thread you
+engaged with has been resolved. A PR with 0 new findings AND 0
+unresolved threads is the cleanest merge state.
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100) {
+          nodes { isResolved }
+        }
+      }
+    }
+  }' -F owner=<owner> -F name=<repo> -F number=<N> \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+```
+
+Zero here means every thread on the PR has been explicitly closed
+(fixed, dismissed with evidence, deferred with issue, or clarified
++ acted on). Humans skimming the PR can trust that nothing slipped.
+
+If this count is >0 but the "new findings" count is 0, you have
+open threads you didn't resolve. Either resolve them now (if they
+were addressed and you just forgot) or go back and act on them
+(if they're actually pending).
 
 ## Secondary stop: Copilot repeats itself
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -18,38 +18,39 @@ arbitrary thresholds.
 ## Merge precondition: required CI checks are green
 
 Before any stop condition becomes a merge decision, **every required
-CI check on the PR head must be in `SUCCESS` (or `SKIPPED`) state.**
-Any other conclusion blocks merge — FAILURE, CANCELLED, TIMED_OUT,
-ACTION_REQUIRED, STARTUP_FAILURE, NEUTRAL, or still in-progress. A
-clean Copilot pass on red CI is not a merge — it's permission to
-stop chasing review comments while the CI problem still needs
-solving.
+CI check on the PR head must be in a green conclusion.** Per GitHub's
+required-check docs, the green set is **SUCCESS, SKIPPED, and
+NEUTRAL** (GitHub treats NEUTRAL as success for required-check
+gating and for dependent-check evaluation). Anything else — FAILURE,
+CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, or still
+in-progress — blocks merge. A clean Copilot pass on red CI is not a
+merge — it's permission to stop chasing review comments while the
+CI problem still needs solving.
 
-Use a whitelist (SUCCESS/SKIPPED are the only green conclusions),
-not a blacklist (FAILURE alone misses CANCELLED, TIMED_OUT, etc. and
-falsely green-lights a broken gate).
+Use a whitelist (SUCCESS, SKIPPED, NEUTRAL are the green
+conclusions), not a blacklist (FAILURE alone misses CANCELLED,
+TIMED_OUT, etc. and falsely green-lights a broken gate).
 
 ```bash
 gh pr view <N> --repo <owner>/<repo> --json statusCheckRollup --jq \
   '{
-    blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion != "SUCCESS" and .conclusion != "SKIPPED")) | {name, conclusion}],
+    blocking: [.statusCheckRollup[]? | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL") | {name, conclusion}],
     pending: [.statusCheckRollup[]? | select(.status != "COMPLETED") | .name],
-    green: ([.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED"))] | length)
+    green: ([.statusCheckRollup[]? | select(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))] | length)
   }'
 ```
 
 **Interpret:**
 
 - `blocking == [] && pending == []` → every completed check is
-  SUCCESS or SKIPPED, nothing in-flight → CI gate is clear.
-- `blocking != []` → investigate by conclusion. Every non-SUCCESS /
-  non-SKIPPED completed conclusion blocks merge. FAILURE means the
+  SUCCESS, SKIPPED, or NEUTRAL → CI gate is clear (matches GitHub's
+  own merge gate).
+- `blocking != []` → investigate by conclusion. FAILURE means the
   code or workflow is broken — if the failure reproduces on `main`
   unchanged it's pre-existing infra (fix it in a dedicated PR, DO
   NOT admin-merge past). CANCELLED / TIMED_OUT / STARTUP_FAILURE
   usually means re-run. ACTION_REQUIRED usually means a
-  first-time-contributor approval or a secret-access prompt. NEUTRAL
-  is rare — treat as block-and-investigate.
+  first-time-contributor approval or a secret-access prompt.
 - `pending != []` → wait. Don't merge mid-CI. Schedule another
   wake-up.
 

--- a/skills/github-pr-review-loop/references/triage-patterns.md
+++ b/skills/github-pr-review-loop/references/triage-patterns.md
@@ -212,7 +212,7 @@ combined commit (or one logical commit per category) keeps the review
 thread coherent:
 
 - Read all inline comments in one pass.
-- Write triage decisions next to each (apply / dismiss / clarify).
+- Write triage decisions next to each (apply / dismiss / clarify / defer).
 - Apply all the "apply" fixes, group by theme if sensible.
 - Commit once (or with semantic boundaries: fix, docs, style).
 - Push.

--- a/skills/github-pr-review-loop/references/triage-patterns.md
+++ b/skills/github-pr-review-loop/references/triage-patterns.md
@@ -1,13 +1,15 @@
-# Triage patterns — apply, dismiss, clarify
+# Triage patterns — apply, dismiss, clarify, defer
 
-Templates and examples for each of the three triage categories, plus the
-evidence checklist for dismissals.
+Templates and examples for each triage category, plus the evidence
+checklist for dismissals and the discipline around resolving threads.
 
 ## Contents
 
 - Apply — fix + cite commit SHA
 - Dismiss — reply with empirical evidence
 - Clarify — ask before guessing
+- Defer — out-of-scope but valid, file a follow-up issue
+- Resolve the thread after replying
 - Evidence checklist (what to run for each claim type)
 - Batching multiple findings into one push
 
@@ -85,6 +87,110 @@ guessing. Ask before changing code.
 Don't use this as a stall — if you have enough to make a decision,
 make it. Clarify is for genuine ambiguity.
 
+## Defer
+
+The finding is correct, but fixing it would expand the scope of this
+PR beyond what's responsible to ship in one change. File a follow-up
+issue capturing the problem, link it in the reply, move on.
+
+**Template:**
+
+> Valid concern — filed as #<N> for a dedicated cycle. Out of scope
+> for this PR, which is focused on <current scope>. The proposed
+> change would <specific consequence: touch unrelated module /
+> require new tests / extend API surface / etc.>.
+
+**When to use Defer instead of Apply:**
+
+- The fix touches code the current PR doesn't otherwise modify.
+- The fix requires new tests to be meaningful.
+- The fix exposes or changes public API that needs its own design
+  discussion.
+- The fix is a refactor that would balloon the diff past a
+  reviewable size.
+
+**When NOT to use Defer (use Apply instead):**
+
+- The fix is a one-line correction to code the current PR already
+  touches.
+- The fix is a doc clarification that was obviously missing.
+- The finding is a typo, misleading comment, or similar trivial fix
+  in a file already in the diff.
+- Deferring would leave the merged code actively wrong rather than
+  just incomplete.
+
+**Examples (real):**
+
+> Valid concern — filed as #61 for a dedicated 1.0.x cycle. Out of
+> scope for this PR, which is focused on the 1.0 public API.
+> Sigstore wiring needs its own workflow changes, a cosign keyless
+> setup, and verification-doc updates; doing it drive-by would
+> extend this release's test surface substantially.
+
+> Filed as #94 — mkdocs-material docs site. Agreed the existing
+> `docs/` tree would benefit from a published site; that's a
+> dedicated workflow + theme + index page that doesn't belong in a
+> release-cut PR.
+
+**The follow-up issue should include:**
+
+- The original Copilot finding (paste or quote it, with PR link).
+- Your assessment of why it's valid.
+- Rough scope: what files, what tests, what API implications.
+- Any prerequisites (e.g. "land after #N before starting this").
+
+Without the issue, `Defer` is indistinguishable from "ignored it".
+Filing the issue is what makes the disposition accountable.
+
+## Resolve the thread after replying
+
+Every Copilot inline comment is a "review thread" with its own
+`isResolved` state. After you reply — whether with an Apply-SHA, a
+Dismissal, a Clarify question the reviewer answered, or a Defer
+with linked issue — mark the thread resolved.
+
+**UI path:** the thread shows a "Resolve conversation" button at the
+bottom of the thread (next to the reply box). Click it. The thread
+collapses and the PR's "unresolved conversations" count drops.
+
+**GraphQL path** (for scripted flow):
+
+```bash
+THREAD_ID=<from reviewThreads query>
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="$THREAD_ID"
+```
+
+See [graphql-snippets.md](graphql-snippets.md) for the thread-listing
+query that gets you the thread IDs.
+
+**Why resolve matters:**
+
+- The PR's "unresolved conversations" count is a stop-condition
+  signal. If it's 0, every thread has been closed-loop — either
+  fixed, dismissed with evidence, deferred with issue, or clarified
+  and then one of those three. Human reviewers skimming the PR
+  can trust this.
+- Resolved threads collapse by default in the UI. Unresolved
+  threads stay expanded. Scrolling a PR with 30 threads, 28 resolved
+  and 2 unresolved, is much less fatiguing than 30 all visible.
+- "Resolved" is the equivalent of closing an issue. Orphaned open
+  threads rot into ambiguity — was it fixed? was it ignored? —
+  and a future maintainer can't tell.
+
+**When NOT to resolve:**
+
+- Before you reply. Resolving silently (no reply) looks dismissive
+  and leaves no record of what you decided.
+- When you've asked a Clarify question and the reviewer hasn't
+  answered yet. Leave it unresolved until they respond.
+- When a human reviewer is still active on the thread. Let them
+  resolve it themselves; don't stomp on their conversation.
+
 ## Evidence checklist
 
 What to run when dismissing each class of claim.
@@ -129,17 +235,15 @@ Reply once pointing at the original thread, then move on:
 Do NOT push a new commit to "silence" it. That invites a third round on
 the same finding.
 
-### Copilot's finding is right in principle, but the fix is out of scope
-
-Acknowledge the finding, file a follow-up issue, and link it:
-
-> Valid concern. Filed as #<N> for a dedicated cycle; out of scope for
-> this PR which is focused on <X>. The proposed change would
-> <consequence outside this PR's scope>.
-
-This keeps the current PR moving without losing the finding.
-
 ### Copilot and a human reviewer disagree
 
 Trust the human. Copilot optimises for patterns; humans see context the
 model missed. Reply to Copilot's comment with the human's rationale.
+
+### You forgot to resolve a thread before merging
+
+If the PR merged with open threads, go back and resolve them from the
+closed PR's page. The UI still lets you resolve a thread post-merge;
+the GraphQL mutation still works. Leaving orphaned open threads on a
+merged PR is a minor mess, but it rots — a month from now a reader
+can't tell if the thread was unaddressed or just forgotten.

--- a/skills/github-pr-review-loop/references/triage-patterns.md
+++ b/skills/github-pr-review-loop/references/triage-patterns.md
@@ -1,0 +1,145 @@
+# Triage patterns — apply, dismiss, clarify
+
+Templates and examples for each of the three triage categories, plus the
+evidence checklist for dismissals.
+
+## Contents
+
+- Apply — fix + cite commit SHA
+- Dismiss — reply with empirical evidence
+- Clarify — ask before guessing
+- Evidence checklist (what to run for each claim type)
+- Batching multiple findings into one push
+
+## Apply
+
+The finding is real. Fix it, commit, push, reply with the commit SHA.
+
+**Template:**
+
+> Fixed in `<sha>` — <one-sentence description of the fix>.
+
+**Examples (real):**
+
+> Fixed in `bb56bfc` — bumped `__version__` to 1.0.0 in
+> src/clickwork/__init__.py. Good catch, this would have broken any
+> consumer's `--version` resolution.
+
+> Fixed in `acc31d3` — `_stub_entry_points` now captures
+> `importlib.metadata.entry_points` before monkeypatching and forwards
+> non-`clickwork.commands` queries through the real impl. Comment also
+> updated to match.
+
+The SHA points the reader at the fix without them having to scroll the
+diff. Keep the one-sentence description specific enough to match the
+finding: "Fixed" alone is low-value; "Fixed typo" on a structural
+refactor is misleading.
+
+## Dismiss
+
+The finding is wrong — a hallucination, a stale claim, or a suggestion
+that contradicts an intentional design choice. Reply with evidence, not
+opinion.
+
+**Template:**
+
+> Dismissing — <one-sentence rationale>. Evidence: <concrete check
+> output or file+line reference>.
+
+**Examples (real):**
+
+> Dismissing (hallucination): `docs/LLM_REFERENCE.md` line 184 has
+> `## Common Footguns` which renders as anchor `#common-footguns`
+> under GitHub-flavored Markdown. The link resolves.
+
+> Reply-dismiss: pre-change state on main was actually
+> `clickwork>=0.2.0,<0.3` from PyPI (verified: `git show
+> origin/main:tools/pyproject.toml | grep clickwork`). Copilot
+> mis-identified the base. PR description updated to match reality.
+
+> Reply-dismiss: both tests call `sender.start()` and use daemon
+> threads with a bounded `ready.wait(timeout=5)` + at most one
+> `os.kill(os.getpid(), SIGINT)`. If run() raises before spawning the
+> child, the sender thread still joins normally because (a) the
+> ready-event timeout fires at 5s max, (b) SIGINT is sent once and
+> then returns, (c) `thread.daemon = True` means it cannot leak past
+> process exit. No teardown risk bounded to 5s.
+
+## Clarify
+
+Genuinely ambiguous finding, or one where acting would require
+guessing. Ask before changing code.
+
+**Template:**
+
+> What specifically would <proposed change> mean here? <your
+> reading of the current behavior>. <your question>.
+
+**Example:**
+
+> What specifically would "improve the error path" mean here? The
+> current `ConfigError` already names the missing key and the file
+> path. Are you looking for a structured exception subtype, or a
+> different wording in the message, or something else?
+
+Don't use this as a stall — if you have enough to make a decision,
+make it. Clarify is for genuine ambiguity.
+
+## Evidence checklist
+
+What to run when dismissing each class of claim.
+
+| Claim type | Verification command | Notes |
+|---|---|---|
+| "Symbol doesn't exist" | `grep -rn 'symbol_name' src/ tests/` | Check the claim's scope — maybe it exists in a file the reviewer didn't scan. |
+| "Import would fail" | `python -c "from module import thing; print(thing)"` | Do this in a fresh venv or the project's venv, not wherever your shell landed. |
+| "Anchor / link broken" | `grep -n '^## Heading' docs/FILE.md` | GitHub anchors are `#`+lowercased+hyphenated. Verify against rendered GitHub view if unsure. |
+| "Test would fail" | Run the test: `pytest path/to/test.py::test_name` | Cite the pass in the reply. If it fails, that's not a dismissal — it's an apply. |
+| "Version / pin is wrong" | `git show origin/main:path/to/file` or `grep -nE 'pattern' file` | Resolve against the actual base state, not your reading. |
+| "Behavior would surprise" | Run the actual behavior — no need to defend a hypothesis | Usually three lines of `python` clears it up. |
+| "Action X will break CI" | Check CI history: `gh run list --branch main --workflow name --limit 5 --json conclusion` | If main shows the same check passing, the claim is specific to the PR. If main is red too, it's pre-existing infra, not a blocker. |
+
+## Batching multiple findings into one push
+
+If a round raises N findings, process all of them before pushing. One
+combined commit (or one logical commit per category) keeps the review
+thread coherent:
+
+- Read all inline comments in one pass.
+- Write triage decisions next to each (apply / dismiss / clarify).
+- Apply all the "apply" fixes, group by theme if sensible.
+- Commit once (or with semantic boundaries: fix, docs, style).
+- Push.
+- Post all replies in one pass.
+- Re-request review once.
+
+Pushing a commit for each finding individually multiplies the Copilot
+rounds and sends the same diff through N reviews. Wasteful.
+
+## Special cases
+
+### Copilot re-raises a finding you already addressed
+
+Reply once pointing at the original thread, then move on:
+
+> Already addressed in `abc1234` (see earlier thread
+> https://github.com/<owner>/<repo>/pull/<N>#discussion_r<id>). No
+> code change needed.
+
+Do NOT push a new commit to "silence" it. That invites a third round on
+the same finding.
+
+### Copilot's finding is right in principle, but the fix is out of scope
+
+Acknowledge the finding, file a follow-up issue, and link it:
+
+> Valid concern. Filed as #<N> for a dedicated cycle; out of scope for
+> this PR which is focused on <X>. The proposed change would
+> <consequence outside this PR's scope>.
+
+This keeps the current PR moving without losing the finding.
+
+### Copilot and a human reviewer disagree
+
+Trust the human. Copilot optimises for patterns; humans see context the
+model missed. Reply to Copilot's comment with the human's rationale.

--- a/skills/github-pr-review-loop/references/triage-patterns.md
+++ b/skills/github-pr-review-loop/references/triage-patterns.md
@@ -12,6 +12,7 @@ checklist for dismissals and the discipline around resolving threads.
 - Resolve the thread after replying
 - Evidence checklist (what to run for each claim type)
 - Batching multiple findings into one push
+- Special cases
 
 ## Apply
 
@@ -65,7 +66,7 @@ opinion.
 > child, the sender thread still joins normally because (a) the
 > ready-event timeout fires at 5s max, (b) SIGINT is sent once and
 > then returns, (c) `thread.daemon = True` means it cannot leak past
-> process exit. No teardown risk bounded to 5s.
+> process exit. Teardown risk is bounded at 5s; no unbounded hang.
 
 ## Clarify
 

--- a/skills/github-pr-review-loop/references/triage-patterns.md
+++ b/skills/github-pr-review-loop/references/triage-patterns.md
@@ -216,12 +216,57 @@ thread coherent:
 - Write triage decisions next to each (apply / dismiss / clarify / defer).
 - Apply all the "apply" fixes, group by theme if sensible.
 - Commit once (or with semantic boundaries: fix, docs, style).
-- Push.
+- **Sweep before you push** (see below).
 - Post all replies in one pass.
 - Re-request review once.
 
 Pushing a commit for each finding individually multiplies the Copilot
 rounds and sends the same diff through N reviews. Wasteful.
+
+### Sweep before you push
+
+When a fix renames a variable, changes a path convention, restructures
+a code block, or alters a placeholder style, grep the whole file (and
+adjacent files in the same skill/directory) for the **old** name /
+path / convention. Copilot will not see the dangling reference as
+"the fix is wrong" — it will see it as an independent bug, and you
+will chase it next round.
+
+Examples where this matters:
+
+- **Renamed a shell variable** (`REPO` → `OWNER/NAME`). Grep for
+  `$REPO`, `\$REPO`, `${REPO}` across every file the refactor
+  touched AND every file that imports its conventions.
+- **Changed a placeholder quoting style** (`<owner>` → `"<owner>"`).
+  Grep for unquoted angle-bracket occurrences in the same section
+  AND in any snippets that copy-paste from the style you just
+  updated.
+- **Renamed a heading, anchor, or file**. Grep for `#old-anchor`
+  and for the old filename; fix every reference before pushing.
+- **Removed or moved a code block's variable definitions**. Every
+  downstream reference to those vars in the same document becomes
+  dangling — sweep for them.
+
+Concrete pattern:
+
+```bash
+# After your fix commit, before git push
+git diff HEAD~1 --name-only | while read f; do
+  echo "=== $f ==="
+  grep -n 'OLD_NAME\|<old_placeholder>\|#old-anchor' "$f"
+done
+```
+
+Why this belongs in the loop: late-round findings often cascade from
+fixes (round N's fix → round N+1 catches a dangling reference the
+fix missed). Each cascade wastes a round. A 60-second sweep before
+push prevents the cascade.
+
+Heuristic for when the recursion is done: if TWO consecutive rounds
+find zero new issues AND no files have changed between them,
+Copilot has actually converged. The skill's "one clean pass" stop
+condition is usually right, but on large refactors a second clean
+pass with no change-surface between them is a stronger signal.
 
 ## Special cases
 

--- a/skills/github-pr-review-loop/references/wave-orchestration.md
+++ b/skills/github-pr-review-loop/references/wave-orchestration.md
@@ -153,9 +153,14 @@ aren't worth it outside of toy examples.
 Don't sit in a loop polling PR status every 30 seconds. Schedule a
 wake-up, do other work, come back when signaled.
 
-In Claude Code: `ScheduleWakeup` tool with a `<<autonomous-loop>>`
-payload at 4-5 minute intervals for single-PR loops, 2-3 minutes
-for multi-PR orchestration.
+In Claude Code: `ScheduleWakeup` tool with a
+`<<autonomous-loop-dynamic>>` payload at 4-5 minute intervals for
+single-PR loops, 2-3 minutes for multi-PR orchestration.
+(`<<autonomous-loop-dynamic>>` is the dynamic-pacing sentinel
+specific to `ScheduleWakeup`; `<<autonomous-loop>>` without the
+`-dynamic` suffix is a different sentinel for CronCreate-mode
+autonomous loops and is NOT interchangeable — using the wrong one
+fails silently and the loop won't resume.)
 
 Stagger wake-ups across PRs so they don't all fire simultaneously:
 
@@ -197,10 +202,10 @@ accumulate rebase debt. `git merge origin/main --no-edit` on the
 worktree branch is usually cleaner than `git rebase` for multi-commit
 branches under active review.
 
-**Copilot context bleeds across PRs.** It doesn't (each PR is a fresh
-context), but the maintainer's context does. Keep PR titles and
-descriptions self-contained so a reviewer flipping between 5 tabs
-doesn't have to reconstruct which PR does what.
+**Copilot context does NOT bleed across PRs** (each PR gets a fresh
+reviewer context), **but the maintainer's context does.** Keep PR
+titles and descriptions self-contained so a human reviewer flipping
+between 5 tabs doesn't have to reconstruct which PR does what.
 
 ## The "prep during bake" playbook
 

--- a/skills/github-pr-review-loop/references/wave-orchestration.md
+++ b/skills/github-pr-review-loop/references/wave-orchestration.md
@@ -111,41 +111,59 @@ resulting implementation PRs through theirs.
 ## Worktree-per-PR discipline
 
 Each PR gets its own worktree, branched from current main (or from
-the previous wave's merged state). This isolates concurrent edits.
+the previous wave's merged state). The worktree lives as a
+**sibling** of the main checkout (not nested inside it), so cleanup
+and isolation both behave predictably.
 
-Run these from the **parent directory** of the repo (one level above
-`<repo>/`), so the worktree resolves as a **sibling** of the main
-checkout, not nested inside it:
+Target layout:
+
+```
+<parent>/
+├── <repo>/                          (main checkout)
+└── <repo>.worktrees/
+    ├── <branch-for-PR-A>/
+    └── <branch-for-PR-B>/
+```
+
+The cleanest way to get there is to `cd <repo>` once and do
+everything with paths relative to the main checkout:
 
 ```bash
-# cwd: parent dir containing <repo>/
-git -C <repo> fetch origin
-mkdir -p <repo>.worktrees
-git -C <repo> worktree add ../<repo>.worktrees/<branch-name> -b <branch-name> origin/main
-cd <repo>.worktrees/<branch-name>
+cd <repo>
+git fetch origin
+mkdir -p ../<repo>.worktrees
+git worktree add ../<repo>.worktrees/<branch-name> -b <branch-name> origin/main
+cd ../<repo>.worktrees/<branch-name>
 # subagent works here
 ```
 
-`mkdir -p` makes the first call on a fresh checkout work —
-`git worktree add` doesn't create the intermediate directory and
-would otherwise fail with a confusing "no such file or directory"
-error on the first worktree of the session.
+Why this shape:
 
-Standard worktree root: `<repo>.worktrees/<branch-name>` at the same
-level as `<repo>/`. If you run `cd <repo>` first, the path resolves
-to `<repo>/<repo>.worktrees/<branch>` — nested inside the main
-checkout — which defeats the isolation and makes cleanup fragile.
+- `cd <repo>` first so every subsequent path is relative to the main
+  checkout — one mental model, no `-C` flag toggles.
+- `mkdir -p ../<repo>.worktrees` creates the sibling directory on a
+  fresh checkout. `git worktree add` does NOT create intermediate
+  directories and would otherwise fail with a confusing "no such
+  file or directory" on the first worktree of the session.
+- `git worktree add ../<repo>.worktrees/<branch-name>` places the
+  worktree one level up from `<repo>/`, as a sibling — if you forget
+  the `../` and write `git worktree add <repo>.worktrees/<branch>`
+  it lands inside `<repo>/<repo>.worktrees/` (nested), defeating
+  isolation.
+- `cd ../<repo>.worktrees/<branch-name>` leaves you in the worktree
+  ready for work.
 
-Clean up after merge (again, from the parent dir):
+Clean up after merge (stay inside the main checkout, not the
+worktree, to avoid removing the directory you're in):
 
 ```bash
-# cwd: parent dir
-git -C <repo> worktree remove ../<repo>.worktrees/<branch-name>
-git -C <repo> branch -d <branch-name>
+cd <repo>   # if you're elsewhere
+git worktree remove ../<repo>.worktrees/<branch-name>
+git branch -d <branch-name>
 ```
 
-Without worktree-per-PR, a subagent editing branch B while another is
-editing branch A in the same checkout causes file-state confusion.
+Without worktree-per-PR, a subagent editing branch B while another
+is editing branch A in the same checkout causes file-state confusion.
 
 ## Parallelism policy — overlap the bake time
 

--- a/skills/github-pr-review-loop/references/wave-orchestration.md
+++ b/skills/github-pr-review-loop/references/wave-orchestration.md
@@ -1,0 +1,202 @@
+# Wave orchestration — running many review loops in parallel
+
+For multi-PR rollouts (closing a batch of related issues in one
+session), the single-PR loop runs in parallel across N PRs.
+
+## Contents
+
+- When to use waves vs sequential
+- The pattern at a glance
+- Wave planning — roadmap PR first
+- Worktree-per-PR discipline
+- Parallelism policy (overlap the bake time)
+- Scheduled wake-ups — never busy-poll
+- Merge-ordering constraints
+- Cross-PR failure modes
+
+## When waves make sense
+
+Use waves when:
+
+- The issues are independent enough that they can be worked in
+  parallel without blocking each other (branch A doesn't reference
+  branch B's unshipped API).
+- The total volume is large enough that a single serial thread would
+  keep a reviewer waiting hours. Rule of thumb: **more than 5 PRs**
+  in a session.
+- The maintainer is available during the session to merge, approve
+  the release gate, and answer clarifications.
+
+Use sequential when:
+
+- PRs have explicit ordering constraints (A must land before B
+  because B documents an API A introduces).
+- You're the only human reviewer and can't effectively watch many
+  simultaneous threads.
+- The repo has strict CI concurrency limits that would serialise
+  parallel runs anyway.
+
+## The pattern
+
+```
+Brainstorm roadmap PR → merge
+  ↓
+Wave N:
+  - Per-wave plan PR (API shapes, branch names, TDD targets) → merge
+  - Prep worktrees for the wave
+  - Dispatch subagents (one per issue) with locked briefs
+  - Review agent diffs in main session
+  - Commit / push / open PRs
+  - For each PR in parallel: run the single-PR review loop
+  - Stagger wake-ups so they don't all fire at once
+  - During Copilot bake time: prep the NEXT wave's worktrees
+  - Merge as each PR hits a stop condition
+  ↓
+Wave N+1 (repeat)
+  ↓
+Release cut
+```
+
+Every layer is a PR of its own. The roadmap is a PR. Each wave plan is
+a PR. Each issue is a PR. Review at every layer.
+
+## Roadmap PR first
+
+Before touching any feature code, write a roadmap PR that pins:
+
+- Wave structure (which issues go in which wave and why)
+- Parallelism policy for this session (sequential, fully parallel,
+  overlap-bake-time)
+- Release target (ship 1.0.0 today? 2.0-rc next week?)
+- Any cross-cutting decisions that will constrain the waves
+
+The roadmap becomes the reference doc. Plans and implementations cite
+it. When in doubt mid-session, re-read the roadmap rather than improvising.
+
+## Per-wave plan PR
+
+Each wave gets its own plan PR before any wave work starts. The plan
+answers:
+
+- Which issues does this wave close?
+- For each issue, what's the API shape or interface? Lock this in
+  before dispatching subagents, because pivots mid-wave are expensive.
+- Branch name per issue (conventional: `<type>/<short-desc>-<issue-num>`).
+- TDD target per issue (red-test exists and fails; what's green?).
+- Any wave-internal merge-order constraints.
+
+Review + merge this plan before opening any implementation PR from the
+wave.
+
+## Worktree-per-PR discipline
+
+Each PR gets its own worktree, branched from current main (or from
+the previous wave's merged state). This isolates concurrent edits:
+
+```bash
+cd <repo>
+git fetch origin
+git worktree add <repo>.worktrees/<branch-name> -b <branch-name> origin/main
+cd <repo>.worktrees/<branch-name>
+# subagent works here
+```
+
+Standard worktree root: `<repo>.worktrees/<branch-name>`. Clean up
+after merge:
+
+```bash
+git worktree remove <repo>.worktrees/<branch-name>
+git branch -d <branch-name>
+```
+
+Without worktree-per-PR, a subagent editing branch B while another is
+editing branch A in the same checkout causes file-state confusion.
+
+## Parallelism policy — overlap the bake time
+
+Copilot takes 30-90s to start a new review and 1-3 min to complete one.
+For N PRs, that bake time is where the win is.
+
+Policy **B** (recommended): while the current wave's PRs are in their
+review loops, use the bake time to prep the NEXT wave's worktrees,
+dispatch its subagents, and stage commits. By the time wave N's PRs
+merge, wave N+1 is already mid-flight.
+
+Policy **A** (sequential): finish wave N fully before starting wave
+N+1. Simpler to reason about; slower overall. Use when cross-wave
+dependencies are high.
+
+Policy **C** (fully parallel): start every wave at once. Don't. The
+cross-wave merge conflicts and concurrent-dispatch cognitive load
+aren't worth it outside of toy examples.
+
+## Scheduled wake-ups — never busy-poll
+
+Don't sit in a loop polling PR status every 30 seconds. Schedule a
+wake-up, do other work, come back when signaled.
+
+In Claude Code: `ScheduleWakeup` tool with a `<<autonomous-loop>>`
+payload at 4-5 minute intervals for single-PR loops, 2-3 minutes
+for multi-PR orchestration.
+
+Stagger wake-ups across PRs so they don't all fire simultaneously:
+
+- PR A: wake in 4 min
+- PR B: wake in 5 min (offset by 1 min from A)
+- PR C: wake in 6 min
+- etc.
+
+When each wake-up fires: check PR status, triage new findings, maybe
+push + re-request, schedule the next wake-up.
+
+## Merge-ordering constraints
+
+Sometimes PR B's content references an API named in PR A that hasn't
+shipped yet. Two options:
+
+**Option 1: explicit merge order.** Document in the wave plan that B
+can't merge before A. Enforce by keeping B in draft until A merges,
+then rebasing B.
+
+**Option 2: don't name the API in B until it exists.** Rephrase B to
+describe the capability without citing the name. Once A merges, open
+a small follow-up PR that adds the name to B's content.
+
+Option 2 is safer for multi-day rollouts — draft PRs can become stale,
+or be merged accidentally. Option 1 is fine for same-session rollouts
+where the human maintainer is paying attention.
+
+## Cross-PR failure modes
+
+**A fix in PR A needs a reciprocal fix in PR B.** Happens when an
+issue is "discovered" mid-wave that touches multiple WIP PRs. Don't
+retrofit silently — open a dedicated follow-up PR C that makes the
+fix as a single atomic change, and reference it from A and B.
+
+**Rebase cascades.** If PR A lands and PR B was branched from pre-A
+main, B needs a rebase. Do this eagerly — don't let a pile of PRs
+accumulate rebase debt. `git merge origin/main --no-edit` on the
+worktree branch is usually cleaner than `git rebase` for multi-commit
+branches under active review.
+
+**Copilot context bleeds across PRs.** It doesn't (each PR is a fresh
+context), but the maintainer's context does. Keep PR titles and
+descriptions self-contained so a reviewer flipping between 5 tabs
+doesn't have to reconstruct which PR does what.
+
+## The "prep during bake" playbook
+
+When wave 1 is in review and you're waiting on Copilot:
+
+1. Open wave 2's plan PR if not already merged.
+2. Pre-create worktrees for wave 2's issues.
+3. Dispatch the first 1-2 subagents for wave 2. They run concurrently
+   with wave 1's review loops.
+4. Watch wave 1's scheduled wake-ups. When a PR hits a stop condition,
+   merge it.
+5. Once all of wave 1 is merged, the wave 2 subagents should be
+   producing diffs. Review, commit, open PRs, start wave 2's loops.
+
+Net effect: wave 2 "starts" as soon as wave 1 enters its review loop,
+not after wave 1 merges. Roughly 30-40% faster than sequential for
+large batches.

--- a/skills/github-pr-review-loop/references/wave-orchestration.md
+++ b/skills/github-pr-review-loop/references/wave-orchestration.md
@@ -5,14 +5,16 @@ session), the single-PR loop runs in parallel across N PRs.
 
 ## Contents
 
-- When to use waves vs sequential
-- The pattern at a glance
-- Wave planning — roadmap PR first
+- When waves make sense
+- The pattern
+- Roadmap PR first
+- Per-wave plan PR
 - Worktree-per-PR discipline
-- Parallelism policy (overlap the bake time)
+- Parallelism policy — overlap the bake time
 - Scheduled wake-ups — never busy-poll
 - Merge-ordering constraints
 - Cross-PR failure modes
+- The "prep during bake" playbook
 
 ## When waves make sense
 
@@ -109,22 +111,31 @@ resulting implementation PRs through theirs.
 ## Worktree-per-PR discipline
 
 Each PR gets its own worktree, branched from current main (or from
-the previous wave's merged state). This isolates concurrent edits:
+the previous wave's merged state). This isolates concurrent edits.
+
+Run these from the **parent directory** of the repo (one level above
+`<repo>/`), so the worktree resolves as a **sibling** of the main
+checkout, not nested inside it:
 
 ```bash
-cd <repo>
-git fetch origin
-git worktree add <repo>.worktrees/<branch-name> -b <branch-name> origin/main
+# cwd: parent dir containing <repo>/
+git -C <repo> fetch origin
+git -C <repo> worktree add ../<repo>.worktrees/<branch-name> -b <branch-name> origin/main
 cd <repo>.worktrees/<branch-name>
 # subagent works here
 ```
 
-Standard worktree root: `<repo>.worktrees/<branch-name>`. Clean up
-after merge:
+Standard worktree root: `<repo>.worktrees/<branch-name>` at the same
+level as `<repo>/`. If you run `cd <repo>` first, the path resolves
+to `<repo>/<repo>.worktrees/<branch>` — nested inside the main
+checkout — which defeats the isolation and makes cleanup fragile.
+
+Clean up after merge (again, from the parent dir):
 
 ```bash
-git worktree remove <repo>.worktrees/<branch-name>
-git branch -d <branch-name>
+# cwd: parent dir
+git -C <repo> worktree remove ../<repo>.worktrees/<branch-name>
+git -C <repo> branch -d <branch-name>
 ```
 
 Without worktree-per-PR, a subagent editing branch B while another is
@@ -215,8 +226,8 @@ When wave 1 is in review and you're waiting on Copilot:
 2. Pre-create worktrees for wave 2's issues.
 3. Dispatch the first 1-2 subagents for wave 2. They run concurrently
    with wave 1's review loops.
-4. Watch wave 1's scheduled wake-ups. When a PR hits a stop condition,
-   merge it.
+4. When wave 1's scheduled wake-ups fire, merge each PR that's hit a
+   stop condition.
 5. Once all of wave 1 is merged, the wave 2 subagents should be
    producing diffs. Review, commit, open PRs, start wave 2's loops.
 

--- a/skills/github-pr-review-loop/references/wave-orchestration.md
+++ b/skills/github-pr-review-loop/references/wave-orchestration.md
@@ -125,41 +125,52 @@ Target layout:
     └── <branch-for-PR-B>/
 ```
 
-The cleanest way to get there is to `cd <repo>` once and do
-everything with paths relative to the main checkout:
+The cleanest way to get there is to `cd "$REPO_DIR"` once and do
+everything with paths relative to the main checkout.  Set two
+shell vars first so nothing is ambiguous on copy-paste (angle-
+bracket placeholders are I/O redirection tokens in bash):
 
 ```bash
-cd <repo>
+# Quote the placeholders on the right-hand side — bash treats
+# '<foo>' as I/O redirection even in assignments, so REPO_DIR=<repo>
+# would fail with "No such file or directory" on copy-paste before
+# you got a chance to substitute your values.
+REPO_DIR="<repo>"         # the bare directory name, e.g. clickwork
+BRANCH="<branch-name>"    # e.g. feat/new-widget-42
+
+cd "$REPO_DIR"
 git fetch origin
-mkdir -p ../<repo>.worktrees
-git worktree add ../<repo>.worktrees/<branch-name> -b <branch-name> origin/main
-cd ../<repo>.worktrees/<branch-name>
+mkdir -p "../$REPO_DIR.worktrees"
+git worktree add "../$REPO_DIR.worktrees/$BRANCH" -b "$BRANCH" origin/main
+cd "../$REPO_DIR.worktrees/$BRANCH"
 # subagent works here
 ```
 
 Why this shape:
 
-- `cd <repo>` first so every subsequent path is relative to the main
-  checkout — one mental model, no `-C` flag toggles.
-- `mkdir -p ../<repo>.worktrees` creates the sibling directory on a
-  fresh checkout. `git worktree add` does NOT create intermediate
-  directories and would otherwise fail with a confusing "no such
-  file or directory" on the first worktree of the session.
-- `git worktree add ../<repo>.worktrees/<branch-name>` places the
-  worktree one level up from `<repo>/`, as a sibling — if you forget
-  the `../` and write `git worktree add <repo>.worktrees/<branch>`
-  it lands inside `<repo>/<repo>.worktrees/` (nested), defeating
-  isolation.
-- `cd ../<repo>.worktrees/<branch-name>` leaves you in the worktree
+- `cd "$REPO_DIR"` first so every subsequent path is relative to
+  the main checkout — one mental model, no `-C` flag toggles.
+- `mkdir -p "../$REPO_DIR.worktrees"` creates the sibling directory
+  on a fresh checkout. `git worktree add` does NOT create
+  intermediate directories and would otherwise fail with a
+  confusing "no such file or directory" on the first worktree of
+  the session.
+- `git worktree add "../$REPO_DIR.worktrees/$BRANCH"` places the
+  worktree one level up from `$REPO_DIR/`, as a sibling — if you
+  drop the `../` and write `git worktree add "$REPO_DIR.worktrees/$BRANCH"`
+  it lands inside `$REPO_DIR/$REPO_DIR.worktrees/` (nested),
+  defeating isolation.
+- `cd "../$REPO_DIR.worktrees/$BRANCH"` leaves you in the worktree
   ready for work.
 
 Clean up after merge (stay inside the main checkout, not the
 worktree, to avoid removing the directory you're in):
 
 ```bash
-cd <repo>   # if you're elsewhere
-git worktree remove ../<repo>.worktrees/<branch-name>
-git branch -d <branch-name>
+# $REPO_DIR and $BRANCH from the earlier assignment block
+cd "$REPO_DIR"   # if you're elsewhere
+git worktree remove "../$REPO_DIR.worktrees/$BRANCH"
+git branch -d "$BRANCH"
 ```
 
 Without worktree-per-PR, a subagent editing branch B while another

--- a/skills/github-pr-review-loop/references/wave-orchestration.md
+++ b/skills/github-pr-review-loop/references/wave-orchestration.md
@@ -120,10 +120,16 @@ checkout, not nested inside it:
 ```bash
 # cwd: parent dir containing <repo>/
 git -C <repo> fetch origin
+mkdir -p <repo>.worktrees
 git -C <repo> worktree add ../<repo>.worktrees/<branch-name> -b <branch-name> origin/main
 cd <repo>.worktrees/<branch-name>
 # subagent works here
 ```
+
+`mkdir -p` makes the first call on a fresh checkout work —
+`git worktree add` doesn't create the intermediate directory and
+would otherwise fail with a confusing "no such file or directory"
+error on the first worktree of the session.
 
 Standard worktree root: `<repo>.worktrees/<branch-name>` at the same
 level as `<repo>/`. If you run `cd <repo>` first, the path resolves

--- a/skills/github-pr-review-loop/references/wave-orchestration.md
+++ b/skills/github-pr-review-loop/references/wave-orchestration.md
@@ -84,9 +84,27 @@ answers:
 - Branch name per issue (conventional: `<type>/<short-desc>-<issue-num>`).
 - TDD target per issue (red-test exists and fails; what's green?).
 - Any wave-internal merge-order constraints.
+- **Size check.** If an issue's scope looks like it will produce a
+  PR over ~300 lines of diff or touching more than 3-4 non-test
+  files, split it now. Smaller PRs get higher-signal Copilot
+  reviews, converge in fewer rounds, and bisect cheaply. This is
+  the last opportunity to split cheaply; once code is landing the
+  only escape is Defer.
 
 Review + merge this plan before opening any implementation PR from the
 wave.
+
+### Brainstorming the plan
+
+The per-wave plan is where the maintainer answers A/B/C questions
+on API shape, error ergonomics, deprecation runway, etc. If you
+have the `superpowers:brainstorming` skill installed, invoke it
+before writing the plan PR — it's built for exactly this kind of
+up-front design conversation and produces the kind of "here are
+the three options, here's what I picked, here's why" artifact that
+the plan PR should contain. This skill (github-pr-review-loop)
+then drives the plan PR through its own review loop and any
+resulting implementation PRs through theirs.
 
 ## Worktree-per-PR discipline
 


### PR DESCRIPTION
## Summary

First pass at packaging the PR review loop discipline as a Claude Code skill, extracted from the clickwork 1.0.0 release session — **24 issues closed across ~25 PRs** (19 implementation PRs + roadmap + per-wave plans + release cut + post-release polish) in ~20 hours of parallel waves.

Opening this as a PR against a minimal `main` so the full diff is reviewable in one pass — drinking our own champagne on the skill's own first change.

## What's in the diff

- **`README.md`** and **`LICENSE`** at the repo root
- **Plugin infra**: `.claude-plugin/marketplace.json` (marketplace manifest at repo root, lists this plugin so `/plugin marketplace add qubitrenegade/github-pr-review-loop` works) and `.claude-plugin/plugin.json` (plugin manifest, `author` is an object per the validated schema)
- **`skills/github-pr-review-loop/SKILL.md`** — the core skill prompt. Frontmatter + compressed description, when-to-invoke criteria, the 4-category triage (apply / dismiss / clarify / defer), how to re-request review via GraphQL `requestReviews(botIds:[...])`, the main loop (with the "sweep before you push" step to prevent late-round cascade), CI-green merge precondition (whitelist of SUCCESS/SKIPPED/NEUTRAL per GitHub's actual gate), stop conditions, "what to never do", small-PR discipline, wave-planning-first, multi-PR scaling, `superpowers:brainstorming` cross-reference
- **`skills/github-pr-review-loop/references/`** — five reference files loaded on demand:
  - `triage-patterns.md` — templates + evidence checklist for each category, batching guidance, thread-resolution discipline, "Sweep before you push" pattern
  - `graphql-snippets.md` — exact `gh api graphql` commands with a shell-safe preamble (quoted-RHS placeholders): `requestReviews`, list/reply inline comments, list/resolve review threads, bulk-resolve, CI-status whitelist, bot-ID discovery + three-variant login asymmetry table
  - `stop-conditions.md` — merge precondition (CI whitelist, committer-date staleness check), primary (zero new findings), complementary (zero unresolved threads), secondary (Copilot repeats), tertiary (volume drying up), anti-patterns
  - `wave-orchestration.md` — multi-PR parallel scaling with the overlap-during-bake-time parallelism policy and worktree-per-PR discipline
  - `case-study-clickwork-1.0.md` — concrete 20-hour run with real Copilot excerpts and the three mistakes that got caught mid-session

## Design choices worth reviewing

- **Gerund-style name** (`github-pr-review-loop`) per Anthropic's skill authoring docs.
- **SKILL.md body ~300 lines**, references load on demand (progressive disclosure). Under the docs' recommended 500-line target.
- **Third-person description** in frontmatter, compressed to 2 sentences focused on "Use when".
- **Stop conditions as concrete signals** (zero new findings / reviewer repeating / volume drying) rather than arbitrary round counts.
- **CI gate is a whitelist, not a blacklist** — `SUCCESS / SKIPPED / NEUTRAL` are green (matches GitHub's actual required-check gate); any other completed conclusion blocks.
- **Explicit 'What to never do'**: never @-mention Copilot for re-review, never admin-merge over failing CI (worked example in case study), never dismiss without evidence, never change code to silence a repeat.
- **'Defer' triage category** for valid-but-out-of-scope findings with the discipline: file follow-up issue, link in reply, resolve the thread.
- **Thread resolution discipline**: every reply closes the loop via `resolveReviewThread` GraphQL mutation.
- **'Sweep before you push'** main-loop step: grep for renamed variables / changed placeholder styles / moved anchors in touched files before committing, so round-N's fix doesn't cascade dangling references into round N+1.
- **Login-asymmetry gotcha** documented: Copilot has 3 different login strings across REST comments / REST reviews / GraphQL — silent empty-result if you use the wrong one.
- **Shell-safe placeholders**: `VAR="<foo>"` convention throughout so commands copy-paste without bash interpreting `<...>` as I/O redirection.

## Install flow that landed

```
/plugin marketplace add qubitrenegade/github-pr-review-loop
/plugin install github-pr-review-loop@qubitrenegade-github-pr-review-loop
```

Or manual: `mkdir -p ~/.claude/skills && cp -r skills/github-pr-review-loop ~/.claude/skills/`.

## Out of scope for v0.1

- Non-GitHub review tools (GitLab Duo, Phabricator).
- Sigstore-adjacent skills.
- CI debugging beyond the trivial "infra-red vs code-red" check.
- Release cutting / tag signing.

## Test plan

- [x] `claude plugin validate .claude-plugin/plugin.json` passes (was failing pre-review because `author` was a string instead of an object)
- [x] 22 rounds of Copilot review on this PR itself surfaced 52+ findings, including 2 real P1 bugs (BOT_ID discovery jq projection, CI-green blacklist-vs-whitelist) and a P2 (timestamp-vs-review-id filter) — all fixed. Every principle in the skill was exercised on its own first change.
- [ ] CI green on this PR (docs + JSON only, no test harness)
- [ ] After merge: install via the marketplace flow and test the skill auto-invokes on a real PR from its description

🤖 Generated with [Claude Code](https://claude.com/claude-code)