### PR TITLE
docs: three merge gates + verify-first triage (#5, #3)

### DIFF
--- a/docs/superpowers/plans/2026-04-20-three-merge-gates-and-verify-first-implementation.md
+++ b/docs/superpowers/plans/2026-04-20-three-merge-gates-and-verify-first-implementation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Apply the docs edits from spec `docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md` to three skill files so the three merge gates (Copilot-review-loop-converged + CI-green + user-authorized) are each first-class in the reader's mental model, and so verification is step one on every triage disposition (not just Dismiss).
 
-**Architecture:** Docs-only PR. No code changes. Three files get edits that re-parent existing guidance under clearer section headings, plus limited net-new content (conditional merge grant pattern, verify-first framing on Apply). Each file is edited independently in its own task; a final verification task cross-checks the three files for consistency.
+**Architecture:** Docs-only PR. No code changes. Three *skill* files get edits that re-parent existing guidance under clearer section headings, plus limited net-new content (conditional merge grant pattern, verify-first framing on Apply). Each skill file is edited independently in its own task; a final verification task cross-checks the three for consistency. This plan document itself ships alongside the skill edits as the fourth file in the PR — it's the audit trail for what changed and why, not part of the framing edits.
 
 **Tech Stack:** Plain Markdown. Git. `gh` CLI.
 

--- a/docs/superpowers/plans/2026-04-20-three-merge-gates-and-verify-first-implementation.md
+++ b/docs/superpowers/plans/2026-04-20-three-merge-gates-and-verify-first-implementation.md
@@ -1,0 +1,535 @@
+# Three Merge Gates + Verify-First Triage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the docs edits from spec `docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md` to three skill files so the three merge gates (Copilot-review-loop-converged + CI-green + user-authorized) are each first-class in the reader's mental model, and so verification is step one on every triage disposition (not just Dismiss).
+
+**Architecture:** Docs-only PR. No code changes. Three files get edits that re-parent existing guidance under clearer section headings, plus limited net-new content (conditional merge grant pattern, verify-first framing on Apply). Each file is edited independently in its own task; a final verification task cross-checks the three files for consistency.
+
+**Tech Stack:** Plain Markdown. Git. `gh` CLI.
+
+**Branch:** `docs/implement-three-merge-gates-verify-first` (already created, based on `main` at `b963be9`).
+
+**Repo:** `qubitrenegade/github-pr-review-loop`.
+
+**Spec reference (authoritative):** `docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md`. Every edit below cites the spec section that defines it.
+
+---
+
+## Task 1: SKILL.md — five framing edits
+
+**Files:**
+- Modify: `skills/github-pr-review-loop/SKILL.md`
+
+**Spec sections:** SKILL.md changes #1-#5
+
+- [ ] **Step 1: Verify current file state matches spec's before-text**
+
+Run:
+
+```bash
+grep -n "Every Copilot inline comment is one of four things" skills/github-pr-review-loop/SKILL.md
+grep -n "Before merging: CI must be green" skills/github-pr-review-loop/SKILL.md
+grep -n 'The user says "merge it"' skills/github-pr-review-loop/SKILL.md
+```
+
+Expected: first grep returns line ~27; second returns the heading line; third returns the bullet.
+
+If any grep returns no match, stop — the spec's starting assumptions no longer hold against the current file. Re-read both the spec and the file before proceeding.
+
+- [ ] **Step 2: Edit #1 — replace triage lead sentence**
+
+Per spec SKILL.md change #1, replace:
+
+> Every Copilot inline comment is one of four things. Decide explicitly; don't guess.
+
+With:
+
+> Every Copilot inline comment is a claim. Verify the claim first, then triage it into one of four dispositions: apply, dismiss, clarify, or defer. Verification is step one for *every* disposition, not just Dismiss.
+
+Use the Edit tool with the exact strings above.
+
+- [ ] **Step 3: Edit #2 — insert opener into "Before merging: CI must be green"**
+
+Per spec SKILL.md change #2, insert this opener **as the first paragraph of the body** of the "Before merging: CI must be green" section (immediately after the heading, before the existing opening line that begins "**A stop condition firing is not permission to merge...**"):
+
+```
+> Merging requires three gates to clear: the Copilot review loop has converged (see Stop conditions — a stop condition has fired, whether that's zero new comments, repeats only, volume dried up, or user override), green CI (below), and user authorization (see Merge authorization). This section covers the CI gate; the other two have their own sections.
+```
+
+(The blockquote is part of the content — this opener is itself a blockquote paragraph.) Existing CI body stays as-is below the new opener.
+
+- [ ] **Step 4: Edit #3 — insert new "Merge authorization" section**
+
+Per spec SKILL.md change #3, add a new `## Merge authorization` section **between** the existing "Before merging: CI must be green" section and the existing "Stop conditions" section. Exact content:
+
+```markdown
+## Merge authorization
+
+User authorization is one of three merge gates, peer to the Copilot review loop and CI gates. None of the three alone implies permission to merge.
+
+Two modes grant the authorization:
+
+- **Standing** — the maintainer is in the session and makes the merge call themselves. This covers both "user says merge" off-ramps mid-loop and the routine case of the maintainer reviewing a PR and hitting merge.
+- **Conditional grant** — the maintainer grants permission up-front with scoped caveats, typically before stepping away. Example template:
+
+  > "Merge when Copilot returns zero new comments AND CI is green. Wait for me if there are repeated comments, comments you have questions about, or red CI."
+
+Any triggered caveat revokes the grant. If the grant says "wait on repeats," a repeat means wait, not "probably fine." Don't reinterpret caveats in light of how close the PR feels to merging.
+
+Absent an explicit grant, the default is ping + wait. A converged review loop + green CI alone = permission to stop chasing review comments, not permission to merge.
+```
+
+- [ ] **Step 5: Edit #4 — insert Stop conditions preface**
+
+Per spec SKILL.md change #4, insert this paragraph **as the new first line** under the `## Stop conditions` heading (before the existing "Stop when any of these fires..." line):
+
+```
+Every stop condition is "stop reviewing," not "ready to merge." Merging requires CI green (previous section) AND user authorization (see Merge authorization). A fired stop condition with red CI or no merge grant = permission to stop chasing review comments, nothing more.
+```
+
+- [ ] **Step 6: Edit #5 — remove "user says 'merge it'" bullet from Stop conditions list**
+
+Per spec SKILL.md change #5, delete this bullet (and its accompanying continuation line if any) from the Stop conditions list:
+
+```
+- **The user says "merge it".** Explicit off-ramp, always valid.
+```
+
+Its content is now covered in the new "Merge authorization" section under **Standing** mode.
+
+- [ ] **Step 7: Verify edits landed**
+
+Run:
+
+```bash
+grep -n "Every Copilot inline comment is a claim" skills/github-pr-review-loop/SKILL.md
+grep -n "Merging requires three gates to clear" skills/github-pr-review-loop/SKILL.md
+grep -n "^## Merge authorization" skills/github-pr-review-loop/SKILL.md
+grep -n "Every stop condition is" skills/github-pr-review-loop/SKILL.md
+grep -nc 'The user says "merge it"' skills/github-pr-review-loop/SKILL.md
+```
+
+Expected: first four greps each return one line with the new content; the fifth (count) returns `0`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add skills/github-pr-review-loop/SKILL.md
+git commit -m "docs(skill): three-gate merge framing + verify-first triage lead
+
+Per docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md (SKILL.md changes #1-#5):
+
+- Reframe triage lead: verification is step one on every disposition
+- Three-gate opener in 'Before merging: CI must be green'
+- New 'Merge authorization' section covering standing + conditional-grant modes
+- Stop conditions preface: 'stop != merge'
+- Remove 'user says merge it' bullet from Stop conditions (now covered in Merge authorization / Standing mode)"
+```
+
+---
+
+## Task 2: stop-conditions.md — four framing edits
+
+**Files:**
+- Modify: `skills/github-pr-review-loop/references/stop-conditions.md`
+
+**Spec sections:** stop-conditions.md changes #1-#4
+
+- [ ] **Step 1: Verify current file state matches spec's before-text**
+
+Run:
+
+```bash
+grep -n "^## Merge precondition: required CI checks are green" skills/github-pr-review-loop/references/stop-conditions.md
+grep -n "^## User escape hatch" skills/github-pr-review-loop/references/stop-conditions.md
+grep -n "^## Putting it together" skills/github-pr-review-loop/references/stop-conditions.md
+grep -n "^## Contents" skills/github-pr-review-loop/references/stop-conditions.md
+```
+
+Expected: all four return one line each with the heading line number.
+
+- [ ] **Step 2: Edit #1 — insert new "Merge precondition: user authorization" section**
+
+Per spec stop-conditions.md change #1, insert a new `## Merge precondition: user authorization` section **immediately after** the existing "Merge precondition: required CI checks are green" section ends, **before** the `## Primary stop: zero new findings` section begins. Exact content:
+
+```markdown
+## Merge precondition: user authorization
+
+User authorization is one of three merge gates, peer to the CI and Copilot review loop gates. None of the three alone implies permission to merge.
+
+Two modes grant the authorization:
+
+- **Standing** — the maintainer is in the session and makes the merge call themselves (in-session "merge it", or the routine case of hitting the merge button after a review pass).
+- **Conditional grant** — the maintainer grants permission up-front with scoped caveats, typically before stepping away. Template:
+
+  > "Merge when Copilot returns zero new comments AND CI is green. Wait for me if there are repeated comments, comments you have questions about, or red CI."
+
+Any triggered caveat revokes the grant and returns to the default ("wait for maintainer"). Don't reinterpret caveats in light of how close the PR feels to merging — the whole point of caveat language is to stop you when a particular signal fires, regardless of surrounding context.
+
+Absent a grant, the default is ping + wait. A converged review loop + green CI alone is NOT permission to merge. Every merge needs all three gates: CI green (above), review loop converged (below), and user authorization (this section).
+```
+
+- [ ] **Step 3: Edit #2 — rename + refocus "User escape hatch" section**
+
+Per spec stop-conditions.md change #2:
+
+- Rename the heading `## User escape hatch` → `## User override of the review loop`.
+- Replace the entire section body with:
+
+```
+If the maintainer says "stop" in-session, that overrides every other review-loop signal for continuing the review. Don't re-litigate. If the maintainer says "merge it," treat that under "Merge precondition: user authorization" above rather than in this override section — "merge it" is a merge-authorization signal, not a review-loop-stop signal.
+
+This section exists because explicit maintainer "stop" (without an accompanying merge instruction) is a valid review-loop-stop signal: "I don't want you chasing this PR any further, regardless of whether it's merging now." Respect it.
+```
+
+- [ ] **Step 4: Edit #3 — rewrite "Putting it together" bullets**
+
+Per spec stop-conditions.md change #3, find the bulleted list in `## Putting it together` whose bullets currently look like:
+
+```
+- Zero new comments on the latest pass → yes and yes → merge.
+- New comments are repeats of addressed threads → yes and yes (action was the earlier fix) → merge.
+- Volume trending to zero, and each remaining comment has been triaged under the usual apply/dismiss/clarify/defer → yes and yes → merge. Triage the nits the same way as any other finding; don't skip them because they're small.
+- User says merge → yes → merge.
+```
+
+Replace the entire list with:
+
+```
+- Zero new comments on the latest pass → review signal exhausted. Merge if CI green AND user authorized (standing or conditional grant); otherwise stop chasing and ping maintainer.
+- New comments are repeats of addressed threads → review signal exhausted (action was the earlier fix). Merge if CI green AND user authorized; otherwise stop chasing and ping maintainer.
+- Volume trending to zero, and each remaining comment has been triaged under the usual apply/dismiss/clarify/defer → review signal exhausted. Merge if CI green AND user authorized; otherwise stop chasing and ping maintainer. Triage the nits the same way as any other finding; don't skip them because they're small.
+- User says merge → merge authorization gate is satisfied (Standing mode). Verify CI green and that the review loop has at least one stop signal fired before merging — "merge authorization" alone doesn't skip the other two gates.
+```
+
+- [ ] **Step 5: Edit #4 — update Contents TOC**
+
+Per spec stop-conditions.md change #4, update the `## Contents` bullet list. Current content:
+
+```
+- Merge precondition: required CI checks are green
+- Primary stop: zero new findings on a Copilot pass
+- Complement: zero unresolved conversation threads
+- Secondary stop: Copilot repeats itself
+- Tertiary stop: suggestion volume dries up
+- User escape hatch
+- Failure-mode stops
+- Anti-patterns (don't stop for these reasons)
+- Putting it together
+```
+
+Replace with:
+
+```
+- Merge precondition: required CI checks are green
+- Merge precondition: user authorization
+- Primary stop: zero new findings on a Copilot pass
+- Complement: zero unresolved conversation threads
+- Secondary stop: Copilot repeats itself
+- Tertiary stop: suggestion volume dries up
+- User override of the review loop
+- Failure-mode stops
+- Anti-patterns (don't stop for these reasons)
+- Putting it together
+```
+
+- [ ] **Step 6: Verify edits landed**
+
+Run:
+
+```bash
+grep -n "^## Merge precondition: user authorization" skills/github-pr-review-loop/references/stop-conditions.md
+grep -n "^## User override of the review loop" skills/github-pr-review-loop/references/stop-conditions.md
+grep -nc "^## User escape hatch" skills/github-pr-review-loop/references/stop-conditions.md
+grep -n "review signal exhausted" skills/github-pr-review-loop/references/stop-conditions.md
+grep -n "Merge authorization" skills/github-pr-review-loop/references/stop-conditions.md
+```
+
+Expected:
+- First grep: one line (new section exists).
+- Second grep: one line (renamed heading exists).
+- Third grep (count): `0` (old heading is gone).
+- Fourth grep: at least 3 lines (the rewritten Putting-it-together bullets).
+- Fifth grep: at least 1 line (cross-reference to SKILL.md's Merge authorization section body, if present — at minimum the text "Merge precondition: user authorization" in Contents).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/github-pr-review-loop/references/stop-conditions.md
+git commit -m "docs(stop-conditions): user-authorization gate + separate review-loop-stop from merge-auth
+
+Per docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md (stop-conditions.md changes #1-#4):
+
+- New 'Merge precondition: user authorization' section (peer to the CI precondition)
+- Rename 'User escape hatch' -> 'User override of the review loop', narrow scope to pure stop signals ('merge it' routes to the merge-auth section instead)
+- Rewrite 'Putting it together' bullets to separate 'review signal exhausted' from 'merge'
+- Update Contents TOC to match"
+```
+
+---
+
+## Task 3: triage-patterns.md — four verify-first edits
+
+**Files:**
+- Modify: `skills/github-pr-review-loop/references/triage-patterns.md`
+
+**Spec sections:** triage-patterns.md changes #1-#4
+
+- [ ] **Step 1: Verify current file state matches spec's before-text**
+
+Run:
+
+```bash
+grep -n "^## Contents" skills/github-pr-review-loop/references/triage-patterns.md
+grep -n "^## Apply" skills/github-pr-review-loop/references/triage-patterns.md
+grep -n "^## Evidence checklist" skills/github-pr-review-loop/references/triage-patterns.md
+```
+
+Expected: three lines, with the Contents heading near line 6, Apply around line 17, Evidence checklist much deeper (around line 195).
+
+- [ ] **Step 2: Edit #1 — insert new "Verify first" section after Contents, before Apply**
+
+Per spec triage-patterns.md change #1, insert a new `## Verify first` section between the end of the `## Contents` list and the start of the `## Apply` section. Exact content:
+
+```markdown
+## Verify first
+
+Every Copilot finding is a *claim*. The discipline is the same regardless of disposition: verify the claim empirically, then pick based on what verification showed.
+
+- Claim correct → **Apply** (the fix is real; include verification evidence in the reply when the claim was non-obvious).
+- Claim wrong → **Dismiss** with that evidence.
+- Can't tell → **Clarify**.
+- Correct but out-of-scope → **Defer** with follow-up issue.
+
+Applying without verifying is the more subtle trap than dismissing without verifying — Copilot confidently misremembers APIs, endpoints, and version strings, so a blindly-applied "just do what the reviewer said" can make the PR worse in a new way. See the Evidence Checklist (below) for commands to run per claim type.
+```
+
+- [ ] **Step 3: Edit #2 — move Evidence Checklist up**
+
+Per spec triage-patterns.md change #2, cut the entire `## Evidence checklist` section (from its heading down to the end of the checklist table, stopping before the next `##` heading) from its current location (after Defer / Resolve) and paste it **immediately after** the new `## Verify first` section, before the `## Apply` section.
+
+Result structure after this edit: Contents → Verify first → Evidence checklist → Apply → Dismiss → Clarify → Defer → Resolve → Batching → Special cases.
+
+- [ ] **Step 4: Edit #3 — add verification-evidence guidance to Apply section**
+
+Per spec triage-patterns.md change #3, find the existing Apply section body. After the paragraph that explains the "Fixed in `<sha>` — ..." template (the paragraph that ends with "Keep the one-sentence description specific enough to match the finding..."), append this new block:
+
+```markdown
+**For non-obvious claims, include the verification in the reply.** The reader benefits from knowing HOW you confirmed the finding was real — especially when Copilot re-surfaces the same claim in a later round. Obvious fixes (typos, broken links in files in the diff) don't need it; anything involving API paths, version pins, function signatures, or behavior claims does.
+
+**Example (non-obvious claim):**
+
+> Fixed in `abc1234` — verified via `grep 'ENTRY_POINT_GROUP' src/clickwork/discovery.py` that the group is `clickwork.commands` (no suffix). Updated 4 docs to match.
+
+**Example (obvious claim — no verification needed):**
+
+> Fixed in `def5678` — typo in README title.
+```
+
+- [ ] **Step 5: Edit #4 — update Contents TOC**
+
+Per spec triage-patterns.md change #4, update the `## Contents` bullet list to reflect the new section order. Current content:
+
+```
+- Apply — fix + cite commit SHA
+- Dismiss — reply with empirical evidence
+- Clarify — ask before guessing
+- Defer — out-of-scope but valid, file a follow-up issue
+- Resolve the thread after replying
+- Evidence checklist (what to run for each claim type)
+- Batching multiple findings into one push
+- Special cases
+```
+
+Replace with:
+
+```
+- Verify first — every finding is a claim, verify before triaging
+- Evidence checklist (what to run for each claim type)
+- Apply — fix + cite commit SHA (include verification for non-obvious claims)
+- Dismiss — reply with empirical evidence
+- Clarify — ask before guessing
+- Defer — out-of-scope but valid, file a follow-up issue
+- Resolve the thread after replying
+- Batching multiple findings into one push
+- Special cases
+```
+
+- [ ] **Step 6: Verify edits landed**
+
+Run:
+
+```bash
+grep -n "^## Verify first" skills/github-pr-review-loop/references/triage-patterns.md
+grep -n "^## Evidence checklist" skills/github-pr-review-loop/references/triage-patterns.md
+grep -n "^## Apply" skills/github-pr-review-loop/references/triage-patterns.md
+grep -n "For non-obvious claims, include the verification in the reply" skills/github-pr-review-loop/references/triage-patterns.md
+grep -c "^## Evidence checklist" skills/github-pr-review-loop/references/triage-patterns.md
+```
+
+Expected:
+- First three greps: one line each, with `Verify first` line number < `Evidence checklist` line number < `Apply` line number.
+- Fourth grep: one line (the new Apply-section block landed).
+- Fifth grep (count): `1` — Evidence checklist appears exactly once (not duplicated if the move failed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/github-pr-review-loop/references/triage-patterns.md
+git commit -m "docs(triage): verify-first framing + move Evidence checklist up + Apply gets verification evidence
+
+Per docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md (triage-patterns.md changes #1-#4):
+
+- New 'Verify first' section at top: every finding is a claim, verify before triaging
+- Evidence checklist moved up (was buried after all four dispositions; now immediately after 'Verify first')
+- Apply section: add 'For non-obvious claims, include the verification in the reply' guidance + two examples (API-grep verified, typo-no-verification)
+- Update Contents TOC to match new order"
+```
+
+---
+
+## Task 4: Cross-file verification sweep
+
+**Files (read only):**
+- `skills/github-pr-review-loop/SKILL.md`
+- `skills/github-pr-review-loop/references/stop-conditions.md`
+- `skills/github-pr-review-loop/references/triage-patterns.md`
+
+**Spec section:** Verification.
+
+- [ ] **Step 1: Consistency read-through**
+
+Open all three files in the order SKILL.md → stop-conditions.md → triage-patterns.md and read them top to bottom.
+
+Confirm each of these holds:
+
+- The three-gate framing uses consistent wording everywhere: "Copilot review loop (converged / fired stop condition)" and "CI green" and "user authorization." No occurrences of "Copilot-clean" or "Copilot-review gate" (hyphenated) should remain in the net-new content.
+- SKILL.md's Stop conditions list has three items, not four (the "user says merge" bullet is gone).
+- stop-conditions.md's Contents lists the new "Merge precondition: user authorization" entry and shows "User override of the review loop" (not "User escape hatch").
+- triage-patterns.md's section order is: Contents → Verify first → Evidence checklist → Apply → Dismiss → Clarify → Defer → Resolve → Batching → Special cases.
+
+If any of these fail, stop and fix in the corresponding task's file before proceeding.
+
+- [ ] **Step 2: Cross-reference link check**
+
+Run:
+
+```bash
+# SKILL.md internally references "Merge authorization" — verify the section exists in SKILL.md itself
+grep -c "^## Merge authorization" skills/github-pr-review-loop/SKILL.md
+
+# stop-conditions.md references "Merge precondition: user authorization" from multiple places
+grep -c "Merge precondition: user authorization" skills/github-pr-review-loop/references/stop-conditions.md
+
+# triage-patterns.md's Verify first references Evidence Checklist
+grep -c "Evidence Checklist" skills/github-pr-review-loop/references/triage-patterns.md
+```
+
+Expected: first grep returns `1`; second returns ≥2 (heading + at least one cross-reference); third returns ≥1 (the reference from Verify first).
+
+If any count is lower than expected, a cross-reference is orphaned — find the referring text and either add the target heading or fix the reference text.
+
+- [ ] **Step 3: Grep sweep for old conflation phrases**
+
+Run:
+
+```bash
+# Literal "yes and yes -> merge" conflation pattern — must be gone
+grep -rn "yes and yes" skills/github-pr-review-loop/ || echo "clean: no yes-and-yes->merge bullets remain"
+
+# "user says merge" must appear in context of merge authorization / Standing, not in Stop conditions
+grep -rn -A1 -B1 'user says "merge it"' skills/github-pr-review-loop/ || echo "clean: no stale stop-condition bullet"
+grep -rn 'The user says "merge it"' skills/github-pr-review-loop/SKILL.md || echo "clean: SKILL.md has no merge-it bullet in Stop conditions"
+
+# Hyphenated forms the spec's last review rounds eliminated
+grep -rn "Copilot-review gate" skills/github-pr-review-loop/ || echo "clean: no Copilot-review hyphenation"
+grep -rn "Copilot-clean" skills/github-pr-review-loop/ || echo "clean: no Copilot-clean shorthand"
+```
+
+Every grep should either return no matches (the "clean:" fallback echo prints) or return matches that are ACCEPTABLE (e.g., "user says merge" inside the Merge authorization section is fine; "user says merge" in the Stop conditions list is not).
+
+Skim each match manually: every remaining occurrence of the searched phrase should be in a NEW or RE-PARENTED section, not in the OLD conflated context.
+
+- [ ] **Step 4: Commit verification notes (if any issues found and fixed)**
+
+If Steps 1-3 surfaced anything that needed fixing, the fix commit goes to whichever file was wrong (re-run the commit pattern from Tasks 1-3 for that file). If everything passed cleanly, no commit is needed for this task.
+
+---
+
+## Task 5: Open PR + run Copilot review loop
+
+**Scope:** This task happens in the main session, NOT via subagent. The review loop needs conversational decision-making (triage calls, merge authorization from user) that doesn't delegate cleanly.
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin docs/implement-three-merge-gates-verify-first
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "docs: three merge gates + verify-first triage (#5, #3)" --body "$(cat <<'EOF'
+## Summary
+
+Implementation PR for the spec merged at b963be9 (PR #8). Addresses issues #5 (merge-gate conflation) and #3 (verification-asymmetry on Apply).
+
+Three skill files edited:
+
+- `skills/github-pr-review-loop/SKILL.md` — triage lead, three-gate opener, new Merge authorization section, Stop conditions preface, remove "user says merge it" bullet
+- `skills/github-pr-review-loop/references/stop-conditions.md` — new "Merge precondition: user authorization" section, rename + refocus "User escape hatch" -> "User override of the review loop", rewrite "Putting it together" bullets to separate "review signal exhausted" from "merge", update Contents
+- `skills/github-pr-review-loop/references/triage-patterns.md` — new "Verify first" section, move Evidence Checklist up, add non-obvious-claim verification guidance to Apply, update Contents
+
+Net-new guidance (not in the current docs):
+
+- Conditional merge grant pattern (the "merge on clean + green; wait on repeats/questions" template the maintainer uses when stepping away)
+- Verify-first on Apply (previously only implicit under Dismiss)
+
+## Out of scope
+
+Issues from the same batch that are explicitly NOT addressed in this PR: #2 (Acknowledge category), #4 (reply+resolve helper), #6 (outside-the-repo blockers), #7 (worktree cleanup). Each is a separate follow-up.
+
+## Test plan
+
+- [ ] Copilot review loop run on this PR (dogfood)
+- [ ] Consistency read-through of the three files after any review-loop edits land
+- [ ] Merge after Copilot signal exhausts + user authorization
+
+Refs #5, #3
+Spec: docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Request Copilot review**
+
+```bash
+REPO="qubitrenegade/github-pr-review-loop"
+PR_NUM="<the-number-gh-pr-create-just-returned>"
+BOT_ID="BOT_kgDOCnlnWA"
+PR_ID=$(gh pr view "$PR_NUM" --repo "$REPO" --json id --jq .id)
+gh api graphql -f query='
+  mutation($prId: ID!, $botId: ID!) {
+    requestReviews(input: {pullRequestId: $prId, botIds: [$botId]}) {
+      pullRequest { number }
+    }
+  }' -f prId="$PR_ID" -f botId="$BOT_ID"
+```
+
+- [ ] **Step 4: Run the review loop (outside this plan)**
+
+Handoff to the github-pr-review-loop skill's normal drill: wait for Copilot, triage each finding (apply / dismiss / clarify / defer — verify first!), reply + resolve per thread, re-request, repeat until a stop condition fires.
+
+Stop condition + user merge authorization → merge. Same drill as the spec PR (#8) itself.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Every numbered edit in the spec (SKILL.md #1-#5, stop-conditions.md #1-#4, triage-patterns.md #1-#4) maps to a named step in Tasks 1-3. No spec requirement is orphaned.
+- **Type consistency:** The section heading `## Merge authorization` in SKILL.md and `## Merge precondition: user authorization` in stop-conditions.md are intentionally different — one is in the top-level skill file (condensed), the other is in the reference doc (detailed). Cross-references use the appropriate form for each target.
+- **Placeholder scan:** No TBDs, TODOs, or "implement later" items. Every edit step shows the exact before-text and after-text.
+- **No new primitives introduced** — this is purely re-parenting + two net-new pieces of guidance already specified in the spec.

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -24,8 +24,7 @@ this skill doesn't apply — standard PR-review habits are fine.
 
 ## The triage — apply, dismiss, clarify, or defer
 
-Every Copilot inline comment is one of four things. Decide explicitly;
-don't guess.
+Every Copilot inline comment is a claim. Verify the claim first, then triage it into one of four dispositions: apply, dismiss, clarify, or defer. Verification is step one for *every* disposition, not just Dismiss.
 
 **Apply** — the finding is real. Fix it in a follow-up commit, push,
 then reply to the comment thread citing the commit SHA so the thread is
@@ -149,6 +148,8 @@ For a single PR, the loop is this. Repeat until a stop condition fires.
 
 ## Before merging: CI must be green
 
+> Merging requires three gates to clear: the Copilot review loop has converged (see Stop conditions — a stop condition has fired, whether that's zero new comments, repeats only, volume dried up, or user override), green CI (below), and user authorization (see Merge authorization). This section covers the CI gate; the other two have their own sections.
+
 **A stop condition firing is not permission to merge — it's permission
 to stop chasing Copilot.** The merge gate is separate: every required
 CI check on the PR head must be in a green conclusion. Per GitHub's
@@ -194,7 +195,24 @@ that's a broken gate, fix it first. See
 "Failure-mode stops" for the clickwork Release-smoke episode that
 taught this lesson the hard way.
 
+## Merge authorization
+
+User authorization is one of three merge gates, peer to the Copilot review loop and CI gates. None of the three alone implies permission to merge.
+
+Two modes grant the authorization:
+
+- **Standing** — the maintainer is in the session and makes the merge call themselves. This covers both "user says merge" off-ramps mid-loop and the routine case of the maintainer reviewing a PR and hitting merge.
+- **Conditional grant** — the maintainer grants permission up-front with scoped caveats, typically before stepping away. Example template:
+
+  > "Merge when Copilot returns zero new comments AND CI is green. Wait for me if there are repeated comments, comments you have questions about, or red CI."
+
+Any triggered caveat revokes the grant. If the grant says "wait on repeats," a repeat means wait, not "probably fine." Don't reinterpret caveats in light of how close the PR feels to merging.
+
+Absent an explicit grant, the default is ping + wait. A converged review loop + green CI alone = permission to stop chasing review comments, not permission to merge.
+
 ## Stop conditions
+
+Every stop condition is "stop reviewing," not "ready to merge." Merging requires CI green (previous section) AND user authorization (see Merge authorization). A fired stop condition with red CI or no merge grant = permission to stop chasing review comments, nothing more.
 
 Stop when any of these fires. Don't keep chasing.
 
@@ -207,7 +225,6 @@ Stop when any of these fires. Don't keep chasing.
 - **Suggestions are drying up in volume.** Round 1 had 7 findings,
   round 3 had 2, round 4 has 1 — the signal is consumed. Next pass is
   usually empty.
-- **The user says "merge it".** Explicit off-ramp, always valid.
 
 See [references/stop-conditions.md](references/stop-conditions.md) for
 the full list including failure-mode stops (reviewer is hallucinating

--- a/skills/github-pr-review-loop/SKILL.md
+++ b/skills/github-pr-review-loop/SKILL.md
@@ -225,10 +225,15 @@ Stop when any of these fires. Don't keep chasing.
 - **Suggestions are drying up in volume.** Round 1 had 7 findings,
   round 3 had 2, round 4 has 1 — the signal is consumed. Next pass is
   usually empty.
+- **User override — the maintainer says "stop".** Explicit review-loop
+  halt. Note: this is distinct from "user says merge," which is a
+  merge-authorization signal, not a stop signal (see Merge
+  authorization).
 
 See [references/stop-conditions.md](references/stop-conditions.md) for
 the full list including failure-mode stops (reviewer is hallucinating
-at high volume, thread has devolved, etc.).
+at high volume, thread has devolved, etc.) and the detailed "User
+override of the review loop" section.
 
 ## What to never do
 

--- a/skills/github-pr-review-loop/references/stop-conditions.md
+++ b/skills/github-pr-review-loop/references/stop-conditions.md
@@ -7,11 +7,12 @@ arbitrary thresholds.
 ## Contents
 
 - Merge precondition: required CI checks are green
+- Merge precondition: user authorization
 - Primary stop: zero new findings on a Copilot pass
 - Complement: zero unresolved conversation threads
 - Secondary stop: Copilot repeats itself
 - Tertiary stop: suggestion volume dries up
-- User escape hatch
+- User override of the review loop
 - Failure-mode stops
 - Anti-patterns (don't stop for these reasons)
 - Putting it together
@@ -67,6 +68,21 @@ gh pr view "$PR_NUM" --repo "$REPO" --json statusCheckRollup --jq \
 See [case-study-clickwork-1.0.md](case-study-clickwork-1.0.md) for
 the Release-smoke episode — concrete example of "failure reproduces
 on main → fix the infra first, don't bypass".
+
+## Merge precondition: user authorization
+
+User authorization is one of three merge gates, peer to the CI and Copilot review loop gates. None of the three alone implies permission to merge.
+
+Two modes grant the authorization:
+
+- **Standing** — the maintainer is in the session and makes the merge call themselves (in-session "merge it", or the routine case of hitting the merge button after a review pass).
+- **Conditional grant** — the maintainer grants permission up-front with scoped caveats, typically before stepping away. Template:
+
+  > "Merge when Copilot returns zero new comments AND CI is green. Wait for me if there are repeated comments, comments you have questions about, or red CI."
+
+Any triggered caveat revokes the grant and returns to the default ("wait for maintainer"). Don't reinterpret caveats in light of how close the PR feels to merging — the whole point of caveat language is to stop you when a particular signal fires, regardless of surrounding context.
+
+Absent a grant, the default is ping + wait. A converged review loop + green CI alone is NOT permission to merge. Every merge needs all three gates: CI green (above), review loop converged (below), and user authorization (this section).
 
 ## Primary stop: zero new findings
 
@@ -250,14 +266,11 @@ gets triaged (apply / dismiss / clarify / defer). The stop decision is about
 whether to wait for another round, not whether to process comments
 already on the PR.
 
-## User escape hatch
+## User override of the review loop
 
-If the human maintainer says "merge it", that overrides every other
-signal. They have context you don't — maybe there's a release cutoff,
-maybe the remaining comments are known non-issues, maybe they've
-reviewed inline and are satisfied.
+If the maintainer says "stop" in-session, that overrides every other review-loop signal for continuing the review. Don't re-litigate. If the maintainer says "merge it," treat that under "Merge precondition: user authorization" above rather than in this override section — "merge it" is a merge-authorization signal, not a review-loop-stop signal.
 
-When the user says merge, merge. Don't re-litigate.
+This section exists because explicit maintainer "stop" (without an accompanying merge instruction) is a valid review-loop-stop signal: "I don't want you chasing this PR any further, regardless of whether it's merging now." Respect it.
 
 ## Failure-mode stops
 
@@ -313,14 +326,10 @@ that will follow.
 The stop decision is: "has the reviewer told me what it has to tell
 me, and have I acted on it?"
 
-- Zero new comments on the latest pass → yes and yes → merge.
-- New comments are repeats of addressed threads → yes and yes (action
-  was the earlier fix) → merge.
-- Volume trending to zero, and each remaining comment has been
-  triaged under the usual apply/dismiss/clarify/defer → yes and
-  yes → merge. Triage the nits the same way as any other finding;
-  don't skip them because they're small.
-- User says merge → yes → merge.
+- Zero new comments on the latest pass → review signal exhausted. Merge if CI green AND user authorized (standing or conditional grant); otherwise stop chasing and ping maintainer.
+- New comments are repeats of addressed threads → review signal exhausted (action was the earlier fix). Merge if CI green AND user authorized; otherwise stop chasing and ping maintainer.
+- Volume trending to zero, and each remaining comment has been triaged under the usual apply/dismiss/clarify/defer → review signal exhausted. Merge if CI green AND user authorized; otherwise stop chasing and ping maintainer. Triage the nits the same way as any other finding; don't skip them because they're small.
+- User says merge → merge authorization gate is satisfied (Standing mode). Verify CI green and that the review loop has at least one stop signal fired before merging — "merge authorization" alone doesn't skip the other two gates.
 
 If none of those fire and the reviewer is still producing signal, run
 another round.

--- a/skills/github-pr-review-loop/references/triage-patterns.md
+++ b/skills/github-pr-review-loop/references/triage-patterns.md
@@ -5,14 +5,40 @@ checklist for dismissals and the discipline around resolving threads.
 
 ## Contents
 
-- Apply — fix + cite commit SHA
+- Verify first — every finding is a claim, verify before triaging
+- Evidence checklist (what to run for each claim type)
+- Apply — fix + cite commit SHA (include verification for non-obvious claims)
 - Dismiss — reply with empirical evidence
 - Clarify — ask before guessing
 - Defer — out-of-scope but valid, file a follow-up issue
 - Resolve the thread after replying
-- Evidence checklist (what to run for each claim type)
 - Batching multiple findings into one push
 - Special cases
+
+## Verify first
+
+Every Copilot finding is a *claim*. The discipline is the same regardless of disposition: verify the claim empirically, then pick based on what verification showed.
+
+- Claim correct → **Apply** (the fix is real; include verification evidence in the reply when the claim was non-obvious).
+- Claim wrong → **Dismiss** with that evidence.
+- Can't tell → **Clarify**.
+- Correct but out-of-scope → **Defer** with follow-up issue.
+
+Applying without verifying is the more subtle trap than dismissing without verifying — Copilot confidently misremembers APIs, endpoints, and version strings, so a blindly-applied "just do what the reviewer said" can make the PR worse in a new way. See the Evidence Checklist (below) for commands to run per claim type.
+
+## Evidence checklist
+
+What to run when dismissing each class of claim.
+
+| Claim type | Verification command | Notes |
+|---|---|---|
+| "Symbol doesn't exist" | `grep -rn 'symbol_name' src/ tests/` | Check the claim's scope — maybe it exists in a file the reviewer didn't scan. |
+| "Import would fail" | `python -c "from module import thing; print(thing)"` | Do this in a fresh venv or the project's venv, not wherever your shell landed. |
+| "Anchor / link broken" | `grep -n '^## Heading' docs/FILE.md` | GitHub anchors are `#`+lowercased+hyphenated. Verify against rendered GitHub view if unsure. |
+| "Test would fail" | Run the test: `pytest path/to/test.py::test_name` | Cite the pass in the reply. If it fails, that's not a dismissal — it's an apply. |
+| "Version / pin is wrong" | `git show origin/main:path/to/file` or `grep -nE 'pattern' file` | Resolve against the actual base state, not your reading. |
+| "Behavior would surprise" | Run the actual behavior — no need to defend a hypothesis | Usually three lines of `python` clears it up. |
+| "Action X will break CI" | Check CI history: `gh run list --branch main --workflow name --limit 5 --json conclusion` | If main shows the same check passing, the claim is specific to the PR. If main is red too, it's pre-existing infra, not a blocker. |
 
 ## Apply
 
@@ -37,6 +63,16 @@ The SHA points the reader at the fix without them having to scroll the
 diff. Keep the one-sentence description specific enough to match the
 finding: "Fixed" alone is low-value; "Fixed typo" on a structural
 refactor is misleading.
+
+**For non-obvious claims, include the verification in the reply.** The reader benefits from knowing HOW you confirmed the finding was real — especially when Copilot re-surfaces the same claim in a later round. Obvious fixes (typos, broken links in files in the diff) don't need it; anything involving API paths, version pins, function signatures, or behavior claims does.
+
+**Example (non-obvious claim):**
+
+> Fixed in `abc1234` — verified via `grep 'ENTRY_POINT_GROUP' src/clickwork/discovery.py` that the group is `clickwork.commands` (no suffix). Updated 4 docs to match.
+
+**Example (obvious claim — no verification needed):**
+
+> Fixed in `def5678` — typo in README title.
 
 ## Dismiss
 
@@ -191,20 +227,6 @@ query that gets you the thread IDs.
   answered yet. Leave it unresolved until they respond.
 - When a human reviewer is still active on the thread. Let them
   resolve it themselves; don't stomp on their conversation.
-
-## Evidence checklist
-
-What to run when dismissing each class of claim.
-
-| Claim type | Verification command | Notes |
-|---|---|---|
-| "Symbol doesn't exist" | `grep -rn 'symbol_name' src/ tests/` | Check the claim's scope — maybe it exists in a file the reviewer didn't scan. |
-| "Import would fail" | `python -c "from module import thing; print(thing)"` | Do this in a fresh venv or the project's venv, not wherever your shell landed. |
-| "Anchor / link broken" | `grep -n '^## Heading' docs/FILE.md` | GitHub anchors are `#`+lowercased+hyphenated. Verify against rendered GitHub view if unsure. |
-| "Test would fail" | Run the test: `pytest path/to/test.py::test_name` | Cite the pass in the reply. If it fails, that's not a dismissal — it's an apply. |
-| "Version / pin is wrong" | `git show origin/main:path/to/file` or `grep -nE 'pattern' file` | Resolve against the actual base state, not your reading. |
-| "Behavior would surprise" | Run the actual behavior — no need to defend a hypothesis | Usually three lines of `python` clears it up. |
-| "Action X will break CI" | Check CI history: `gh run list --branch main --workflow name --limit 5 --json conclusion` | If main shows the same check passing, the claim is specific to the PR. If main is red too, it's pre-existing infra, not a blocker. |
 
 ## Batching multiple findings into one push
 

--- a/skills/github-pr-review-loop/references/triage-patterns.md
+++ b/skills/github-pr-review-loop/references/triage-patterns.md
@@ -1,7 +1,7 @@
 # Triage patterns — apply, dismiss, clarify, defer
 
 Templates and examples for each triage category, plus the evidence
-checklist for dismissals and the discipline around resolving threads.
+checklist for verifying any finding and the discipline around resolving threads.
 
 ## Contents
 
@@ -28,7 +28,7 @@ Applying without verifying is the more subtle trap than dismissing without verif
 
 ## Evidence checklist
 
-What to run when dismissing each class of claim.
+What to run to verify each class of claim. The same commands work whether you end up applying the fix, dismissing the finding, or deferring — verification comes first, disposition second.
 
 | Claim type | Verification command | Notes |
 |---|---|---|


### PR DESCRIPTION
## Summary

Implementation PR for the spec merged at b963be9 (PR #8). Addresses issues #5 (merge-gate conflation) and #3 (verification-asymmetry on Apply).

Four files ship in this PR: three **skill files** that carry the framing edits, plus the **plan document** itself as the audit trail for what changed and why.

Skill files edited:

- `skills/github-pr-review-loop/SKILL.md` — new triage lead ("verify the claim first"), three-gate opener in the "Before merging" section, new `## Merge authorization` section, Stop conditions preface separating "stop != merge", removed the "user says merge it" bullet (now under Merge authorization / Standing), added a separate "User override" stop bullet for the "user says stop" case.
- `skills/github-pr-review-loop/references/stop-conditions.md` — new "Merge precondition: user authorization" section (peer to the CI precondition), renamed "User escape hatch" → "User override of the review loop" with narrowed stop-only scope, rewrote the "Putting it together" bullets to decouple "review signal exhausted" from "merge", updated Contents TOC.
- `skills/github-pr-review-loop/references/triage-patterns.md` — new "Verify first" section at the top, moved the Evidence Checklist up under it (the checklist now frames as "verify any finding," not just dismiss), added "include verification in the Apply reply for non-obvious claims" guidance with paired examples, updated Contents TOC, broadened the file-lead and checklist-intro framing to match the new verify-first scope.

Plan doc:

- `docs/superpowers/plans/2026-04-20-three-merge-gates-and-verify-first-implementation.md` — the implementation plan followed to make the three skill edits above. Shipped alongside as documentation of the change process, not as part of the framing itself.

## Net-new guidance (not previously documented)

- **Conditional merge grant pattern** — the "merge on clean + green; wait on repeats/questions" template the maintainer uses when stepping away. The Standing vs. Conditional-grant distinction is made explicit with caveat-revocation rules.
- **Verify-first on Apply** — previously only implicit under Dismiss. Apply replies now recommend including verification evidence for non-obvious claims (API paths, version pins, function signatures, behavior claims) — because Copilot confidently misremembers these.

## Dogfooding

This PR was built by running the github-pr-review-loop skill against its own spec PR (#8), which saw 8 Copilot rounds (4/2/2/1/1/1/1/0 findings) before converging. Several of the round-by-round catches exercised the new framing before it was written down — the round-3 "user says merge" bullet contradiction is exactly the conflation #5 is designed to eliminate.

## Out of scope

Issues from the same batch that are explicitly NOT addressed in this PR:

- **#2** (Acknowledge triage category for design-voting)
- **#4** (reply+resolve helper script)
- **#6** (outside-the-repo blockers escalation)
- **#7** (worktree cleanup)

Each will get its own follow-up PR.

## Test plan

- [ ] Copilot review loop run on this PR (dogfood)
- [ ] Cross-file three-gate consistency audit after any review-loop edits land
- [ ] Merge after Copilot signal exhausts + maintainer authorization (per the new framing)

Refs #5, #3
Spec: `docs/superpowers/specs/2026-04-19-three-merge-gates-and-verify-first-design.md`
Plan: `docs/superpowers/plans/2026-04-20-three-merge-gates-and-verify-first-implementation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)