### PR TITLE
docs(spec): worktree cleanup pointer (#7)

### DIFF
--- a/docs/superpowers/specs/2026-04-21-worktree-cleanup-pointer-design.md
+++ b/docs/superpowers/specs/2026-04-21-worktree-cleanup-pointer-design.md
@@ -1,0 +1,62 @@
+# Worktree cleanup pointer — design
+
+**Date:** 2026-04-21
+**Issue:** [#7](https://github.com/qubitrenegade/github-pr-review-loop/issues/7)
+**Type:** Docs / framing PR — no code changes.
+
+## Problem
+
+The `github-pr-review-loop` skill mentions using worktrees in its `## Scaling to multiple PRs` section ("One worktree per PR, branched from current main.") and in `wave-orchestration.md`, but gives no guidance on their lifecycle. In practice, worktrees accumulate after `gh pr merge --delete-branch` — the remote branch gets deleted, `gh` may drop the local branch too, but the worktree directory stays until someone runs `git worktree remove <path>` and cleans up the directory.
+
+Issue #7 asked "should we consider cleaning up worktrees after we merge a branch?"
+
+The answer, after brainstorming: **this skill shouldn't own worktree lifecycle.** That's `superpowers:using-git-worktrees` (creation) and `superpowers:finishing-a-development-branch` (cleanup). Both skills already exist and prescribe the discipline. What this skill is missing is a **discoverability pointer** — a reader following the `github-pr-review-loop` flow into the Scaling section encounters "use worktrees" but no onward link to the lifecycle skills.
+
+## Design
+
+### Scope
+
+Single-file, single-bullet edit to `skills/github-pr-review-loop/SKILL.md`. No new content, no new patterns — just a pointer to the existing sibling skills so the hand-off is discoverable.
+
+After merging the implementation PR, comment on issue #7 linking to the merged PR and close the issue.
+
+**Out of scope** — no script, no hook, no new lifecycle content. The discipline itself lives in the other skills; this PR only surfaces the pointer.
+
+### Design choices (locked in during brainstorm)
+
+- **Docs pointer, not prescriptive lifecycle content.** Option A (document the cleanup steps here), Option B (ship a helper script), Option C (git post-merge hook) were all considered but rejected. Worktree cleanup is not this skill's concern — `superpowers:finishing-a-development-branch` already owns that discipline. Duplicating it here would create drift between the two skills. The right move is a short cross-reference.
+- **Close the issue with the PR link** — makes the trail findable. "Not our problem, see these other skills" is a complete answer when it comes with a pointer.
+
+### SKILL.md changes
+
+#### 1. Add a worktree-lifecycle pointer bullet to the Scaling section's bullet list
+
+The existing `## Scaling to multiple PRs` section has a 3-bullet list describing orchestration around parallel PRs. Current bullets (for reference — do not modify the existing three):
+
+- One worktree per PR, branched from current main. Isolates concurrent edits...
+- Scheduled wake-ups per PR at staggered intervals...
+- Overlap the next wave's prep (branch creation, agent briefing)...
+
+Append a new 4th bullet after the existing three, before the "See [references/wave-orchestration.md]..." paragraph that follows the list:
+
+```markdown
+- **Worktree lifecycle isn't owned by this skill.** See `superpowers:using-git-worktrees` for creation (directory selection, safety checks, setup) and `superpowers:finishing-a-development-branch` for cleanup after merge. Don't let stale worktrees accumulate — `gh pr merge --delete-branch` removes the remote branch but leaves the local worktree directory in place until the finishing-a-development-branch discipline runs.
+```
+
+## Verification
+
+Docs-only; single-bullet edit:
+
+1. **Read-through check** — open SKILL.md's Scaling section and confirm the 4 bullets read cleanly together. The new bullet shouldn't break parallel structure with the existing three.
+2. **Cross-reference check** — confirm both `superpowers:using-git-worktrees` and `superpowers:finishing-a-development-branch` are referenced by their correct skill-ID form.
+3. **Copilot review loop** — run the normal drill.
+
+After merge: post a comment on issue #7 linking to the merged PR, then close the issue.
+
+No automated tests. No code changes.
+
+## Out-of-scope / follow-ups
+
+- **#4** (reply+resolve helper script) — distinct effort, own PR.
+
+After this PR merges, #4 is the last remaining issue in the batch that motivated the #5+#3, #2, and #6 spec cycles.

--- a/docs/superpowers/specs/2026-04-21-worktree-cleanup-pointer-design.md
+++ b/docs/superpowers/specs/2026-04-21-worktree-cleanup-pointer-design.md
@@ -6,7 +6,7 @@
 
 ## Problem
 
-The `github-pr-review-loop` skill mentions using worktrees in its `## Scaling to multiple PRs` section ("One worktree per PR, branched from current main.") and in `wave-orchestration.md`, but gives no guidance on their lifecycle. In practice, worktrees accumulate after `gh pr merge --delete-branch` — the remote branch gets deleted, `gh` may drop the local branch too, but the worktree directory stays until someone runs `git worktree remove <path>` and cleans up the directory.
+The `github-pr-review-loop` skill mentions using worktrees in its `## Scaling to multiple PRs` section ("One worktree per PR, branched from current main.") and in `skills/github-pr-review-loop/references/wave-orchestration.md`, but gives no guidance on their lifecycle. In practice, worktrees accumulate after `gh pr merge --delete-branch` — the remote branch gets deleted, `gh` may drop the local branch too, but the worktree directory stays until someone runs `git worktree remove <path>` (and removes the directory, which `git worktree remove` may leave behind if there are untracked files and `--force` wasn't used).
 
 Issue #7 asked "should we consider cleaning up worktrees after we merge a branch?"
 
@@ -40,7 +40,14 @@ The existing `## Scaling to multiple PRs` section has a 3-bullet list describing
 Append a new 4th bullet after the existing three, before the "See [references/wave-orchestration.md]..." paragraph that follows the list:
 
 ```markdown
-- **Worktree lifecycle isn't owned by this skill.** See `superpowers:using-git-worktrees` for creation (directory selection, safety checks, setup) and `superpowers:finishing-a-development-branch` for cleanup after merge. Don't let stale worktrees accumulate — `gh pr merge --delete-branch` removes the remote branch but leaves the local worktree directory in place until the finishing-a-development-branch discipline runs.
+- **Worktree lifecycle isn't owned by this skill.** See
+  `superpowers:using-git-worktrees` for creation (directory selection,
+  safety checks, setup) and
+  `superpowers:finishing-a-development-branch` for cleanup after merge.
+  Don't let stale worktrees accumulate — `gh pr merge --delete-branch`
+  removes the remote branch but leaves the local worktree directory in
+  place until the `superpowers:finishing-a-development-branch`
+  discipline runs.
 ```
 
 ## Verification
@@ -59,4 +66,4 @@ No automated tests. No code changes.
 
 - **#4** (reply+resolve helper script) — distinct effort, own PR.
 
-After this PR merges, #4 is the last remaining issue in the batch that motivated the #5+#3, #2, and #6 spec cycles.
+After this PR merges, #4 is the last remaining issue in the batch that motivated the earlier spec cycles for issues #5, #3, #2, and #6.

--- a/docs/superpowers/specs/2026-04-21-worktree-cleanup-pointer-design.md
+++ b/docs/superpowers/specs/2026-04-21-worktree-cleanup-pointer-design.md
@@ -6,11 +6,11 @@
 
 ## Problem
 
-The `github-pr-review-loop` skill mentions using worktrees in its `## Scaling to multiple PRs` section ("One worktree per PR, branched from current main.") and in `skills/github-pr-review-loop/references/wave-orchestration.md`, but gives no guidance on their lifecycle. In practice, worktrees accumulate after `gh pr merge --delete-branch` — the remote branch gets deleted, `gh` may drop the local branch too, but the worktree directory stays until someone runs `git worktree remove <path>` (and removes the directory, which `git worktree remove` may leave behind if there are untracked files and `--force` wasn't used).
+The `github-pr-review-loop` skill mentions using worktrees in its `## Scaling to multiple PRs` section ("One worktree per PR, branched from current main.") and in `skills/github-pr-review-loop/references/wave-orchestration.md`, but gives no guidance on their lifecycle. In practice, worktrees accumulate after `gh pr merge --delete-branch` — the flag deletes both the remote branch and the local branch (the local delete may fail if the branch is checked out in a worktree or has unpushed commits) — but the worktree directory itself always stays until someone runs `git worktree remove <path>` and removes the directory (and `git worktree remove` may leave the directory behind if it contains untracked files and `--force` wasn't used).
 
 Issue #7 asked "should we consider cleaning up worktrees after we merge a branch?"
 
-The answer, after brainstorming: **this skill shouldn't own worktree lifecycle.** That's `superpowers:using-git-worktrees` (creation) and `superpowers:finishing-a-development-branch` (cleanup). Both skills already exist and prescribe the discipline. What this skill is missing is a **discoverability pointer** — a reader following the `github-pr-review-loop` flow into the Scaling section encounters "use worktrees" but no onward link to the lifecycle skills.
+The answer, after brainstorming: **this skill shouldn't own worktree lifecycle.** That's `superpowers:using-git-worktrees` (creation) and `superpowers:finishing-a-development-branch` (cleanup) — both part of the external `superpowers` plugin. Both skills already exist and prescribe the discipline. What this skill is missing is a **discoverability pointer** — a reader following the `github-pr-review-loop` flow into the Scaling section encounters "use worktrees" but no onward link to the lifecycle skills.
 
 ## Design
 
@@ -40,14 +40,15 @@ The existing `## Scaling to multiple PRs` section has a 3-bullet list describing
 Append a new 4th bullet after the existing three, before the "See [references/wave-orchestration.md]..." paragraph that follows the list:
 
 ```markdown
-- **Worktree lifecycle isn't owned by this skill.** See
-  `superpowers:using-git-worktrees` for creation (directory selection,
-  safety checks, setup) and
+- **Worktree lifecycle isn't owned by this skill.** If you have the
+  `superpowers` plugin installed, see `superpowers:using-git-worktrees`
+  for creation (directory selection, safety checks, setup) and
   `superpowers:finishing-a-development-branch` for cleanup after merge.
-  Don't let stale worktrees accumulate — `gh pr merge --delete-branch`
-  removes the remote branch but leaves the local worktree directory in
-  place until the `superpowers:finishing-a-development-branch`
-  discipline runs.
+  Without that plugin, apply the same discipline manually:
+  `git worktree add <path>` to create, `git worktree remove <path>`
+  (plus removing the directory if files remain) after merge. Don't
+  let stale worktrees accumulate — `gh pr merge --delete-branch`
+  deletes the branches but leaves the worktree directory in place.
 ```
 
 ## Verification


### PR DESCRIPTION
## Summary

- Spec for a minimal docs PR: add a single bullet to `SKILL.md`'s `## Scaling to multiple PRs` section pointing at the two sibling skills that actually own worktree lifecycle.
- **Not adding lifecycle content to this skill** — `superpowers:using-git-worktrees` owns creation; `superpowers:finishing-a-development-branch` owns cleanup. Both already exist and prescribe the discipline. This PR just makes the hand-off discoverable from the `github-pr-review-loop` flow.
- Addresses issue #7 ("should we consider cleaning up worktrees after we merge a branch?") — answer is "yes, but not in this skill."

## Design choices (from brainstorm)

- Rejected A (document cleanup steps here), B (ship a helper script), and C (git `post-merge` hook). All would duplicate or extend discipline the sibling skills already own.
- Closing #7 with a PR-link comment after this spec's implementation PR merges — keeps the trail findable.

## Out of scope

- **#4** (reply+resolve helper script) — distinct effort, own PR. Last remaining issue in the batch after this.

## Test plan

- [ ] Spec reviewed by maintainer
- [ ] Copilot review loop on the spec PR
- [ ] After merge: write implementation plan + execute + open impl PR
- [ ] After impl PR merges: close #7 with link

Refs #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)